### PR TITLE
Add GitHub URL to show in pkgdown site

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,5 +40,6 @@ Suggests:
     devtools,
     covr,
     ggplot2
-URL: https://merck.github.io/r2rtf/
+URL: https://merck.github.io/r2rtf/, https://github.com/Merck/r2rtf
+BugReports: https://github.com/Merck/r2rtf/issues
 Config/testthat/edition: 3


### PR DESCRIPTION
This will give you more links than CRAN alone in the sidebar of the pkgdown site.

<img width="300" alt="Screen Shot 2021-05-17 at 11 54 29 AM" src="https://user-images.githubusercontent.com/199363/118519035-bd62fd00-b706-11eb-91fc-62a6929d46f0.png">
