### PR TITLE
update customized theme for pkgdown 2.0.0

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,17 +1,34 @@
 destination: docs
+
+url: https://merck.github.io/r2rtf/
+
 template:
-  package: r2rtf
   bootstrap: 5
+  bslib:
+    primary: "#00857c"
+    navbar-light-brand-color: "#fff"
+    navbar-light-brand-hover-color: "#fff"
+    navbar-light-color: "#fff"
+    navbar-light-hover-color: "#fff"
+    navbar-light-active-color: "#fff"
+    dropdown-link-hover-color: "#fff"
+    dropdown-link-hover-bg: "#00857c"
+
+footer:
+  structure:
+    left: [developed_by, built_with, legal]
+    right: [blank]
+  components:
+    legal: "<br>Copyright &copy; Merck Sharp & Dohme Corp., a subsidiary of Merck & Co., Inc., Kenilworth, NJ, USA."
+    blank: "<span></span>"
+
 navbar:
-  type: default
   left:
-    - icon: fa-home
-      href: index.html
     - icon: fas fa-file-code
       text: "Reference"
       href: reference/index.html
     - icon: fas fa-play-circle
-      text: "Get Start"
+      text: "Get started"
       href: articles/r2rtf.html
     - text: "Articles"
       icon: fas fa-book
@@ -22,10 +39,10 @@ navbar:
   right:
     - icon: fab fa-github
       text: "Source code"
-      href: https://github.com/Merck/r2rtf/
+      href: https://github.com/Merck/r2rtf
 
 articles:
-- title: Get Start
+- title: Get Started
   contents:
   - r2rtf
 - title: TLF Examples
@@ -130,4 +147,3 @@ reference:
   - "utf8Tortf"
   - "vertical_justification"
   - "write_rtf_para"
-

--- a/inst/pkgdown/templates/footer.html
+++ b/inst/pkgdown/templates/footer.html
@@ -1,5 +1,0 @@
-<div class="copyright">
-  <p>{{#package}}Developed by {{{authors}}}.{{/package}} Site built with pkgdown {{#pkgdown}}{{version}}{{/pkgdown}}.
-  </p>
-  <p>Copyright &copy; 2021 Merck Sharp & Dohme Corp., a subsidiary of Merck & Co., Inc., Kenilworth, NJ, USA.</p>
-</div>

--- a/pkgdown/extra.css
+++ b/pkgdown/extra.css
@@ -1,173 +1,24 @@
-/* typography */
-
-body {
-    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
-    font-size: 16px;
-    line-height: 24px;
-    color: #212529;
-}
-
-/* content padding */
-
-body>.container {
-    padding-top: 60px;
-}
-
-/* navbar */
-
-.navbar-default .navbar-link {
-    color: #fff;
-}
-
-.navbar-default .navbar-link:hover {
-    color: #fff;
-}
-
-.navbar-default .navbar-toggle .icon-bar {
-    background-color: #fff;
-}
-
-.label-default {
-    background-color: #95a5a6;
-}
-
-a {
-    color: #00857c;
-}
-
-a:hover, a:active {
-    color: #005c55;
-}
-
-/* navbar again */
-
-.navbar-default .navbar-nav>li>a:hover, .navbar-default .navbar-nav>li>a:focus {
-    color: #fff;
-    /*Sets the text hover color on navbar*/
-}
-
-.navbar-default .navbar-nav>.active>a, .navbar-default .navbar-nav>.active>a:hover, .navbar-default .navbar-nav>.active>a:focus {
-    color: #fff;
-    /*BACKGROUND color for active*/
-    background-color: #00857c;
-}
-
-.dropdown-menu>li>a:hover, .dropdown-menu>li>a:focus {
-    color: #fff;
-    text-decoration: none;
-    background-color: #00857c;
-    /*change color of links in drop down here*/
-}
-
-.nav>li>a:hover, .nav>li>a:focus {
-    text-decoration: none;
-    background-color: silver;
-    /*Change rollover cell color here*/
-}
-
-.navbar-default .navbar-nav>li>a {
-    color: white;
-    /*Change active text color here*/
-}
-
-.navbar-default {
-    background-color: #00857c;
-    border-color: #fff !important;
-}
-
-.navbar-mrk {
-    background-color: #005c55;
-    color: #fff !important;
-    margin-right: 0px;
-}
-
-.navbar-mrk>li>a {
-    color: #fff !important;
-}
-
-.navbar-mrk>.active>a {
-    background-color: #005c55 !important;
-}
-
-.navbar-mrk>.open>a:focus, .nav-pills>.open>a:focus {
-    background-color: #005c55 !important;
-}
-
-.dropdown-menu>.active>a, .dropdown-menu>.active>a:focus {
-    background-color: #005c55 !important;
-}
-
-.contents-mrk>li>a:focus, .nav-pills>li>a:focus {
+/* navbar background */
+.bg-light, .navbar-light {
     background-color: #00857c !important;
+}
+
+/* navbar version number */
+.nav-text.text-muted {
+    color: #d9e7e6 !important;
+}
+
+/* navbar link status */
+.navbar-light .navbar-nav .nav-item>.nav-link:hover {
+    background: #005c55;
+}
+
+.navbar-light .navbar-nav .nav-item.active>.nav-link:hover {
     color: #fff;
-}
-
-.contents-mrk>li.active>a, .nav-pills>li.active>a {
-    background-color: #005c55 !important;
-}
-
-.contents-mrk>li>a, .nav-pills>li>a {
-    background-color: #00857c !important;
-    color: #fff;
-}
-
-/* small screen expanded dropdown (vignettes) link color */
-
-@media (max-width: 767px) {
-    .navbar-default .navbar-nav .open .dropdown-menu>li>a {
-        color: #fff;
-    }
-    .navbar-default .navbar-nav .open .dropdown-menu>.active>a, .navbar-default .navbar-nav .open .dropdown-menu>.active>a:focus, .navbar-default .navbar-nav .open .dropdown-menu>.active>a:hover {
-        color: #fff;
-    }
-}
-
-/* toc */
-
-nav[data-toggle='toc'] .nav>li>a {
-    font-size: 15px;
-    color: #747479;
-}
-
-/* syntax highlighting */
-
-pre, code {
-    font-family: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
-    font-size: 14px;
-}
-
-code a, pre a {
-    color: #00857c;
-}
-
-.fl {
-    color: #00857c;
-}
-
-.ch, .st {
-    color: #0c2340;
-}
-
-.kw {
-    color: #00857c;
-}
-
-/* copy code button */
-
-.btn-copy-ex {
-    background-color: #00857c;
-    border-color: #005c55;
-}
-
-.btn-copy-ex:hover {
-    background-color: #005c55;
-    border-color: #005c55;
 }
 
 /* footer */
-
 footer {
-    margin-top: 45px;
-    padding: 45px 0 55px;
-    color: #747479;
+    padding-top: 1rem;
+    padding-bottom: 1rem;
 }


### PR DESCRIPTION
This PR updated the customized theme for pkgdown 2.0.0.

Two notes:

1. This PR itself can pass the build. That CI error about missing topics is not relevant to this change. To fix it, tag all the internal functions with `@keywords internal` or `@noRd` and run roxygen2: https://community.rstudio.com/t/keywords-internal-vs-nord/35119 This is beyond the PR scope so I will let you do the honor.

2. Steps to patch a package with the previous Bootstrap 3 theme manually if needed:

- Remove `inst/pkgdown/` completely
- Replace `pkgdown/extra.css` with the new version
- In `_pkgdown.yml`
  - Add the `url` section and replace with your site base URL (for search to work properly)
  - Replace the old `template` section with the new version
  - Add the new `footer` section
  - Remove the `type` field from the `navbar` section if any