### PR TITLE
add heading hierarchy

### DIFF
--- a/vignettes/design-pattern.Rmd
+++ b/vignettes/design-pattern.Rmd
@@ -21,29 +21,29 @@ knitr::opts_chunk$set(
 )
 ```
 
-
-```{r setup, message=FALSE, echo=FALSE}
+```{r, message=FALSE, echo=FALSE}
 library(dplyr)
 library(r2rtf)
 ```
 
-## Overview 
+## Overview
 
-> This document is for developers who would like to understand the internal of the `r2rtf` package.  
+> This document is for developers who would like to understand the internal of the `r2rtf` package.
 
-The r2rtf package is developed to standardize the approach to generate highly customized 
-tables, listings and figures (TLFs) in RTF format and provide flexibility to 
+The r2rtf package is developed to standardize the approach to generate highly customized
+tables, listings and figures (TLFs) in RTF format and provide flexibility to
 customize table appearance for table title, subtitle, column header, footnote, and data source.
 
-The r2rtf package is designed to enables pipes (`%>%`), 
+The r2rtf package is designed to enables pipes (`%>%`),
 the first argument are all `tbl` except `rtf_read_figure()` and `write_rtf()`.
 A minimal example summarized the major steps in using r2rtf package to
 create a table or listing after a data frame is ready.
-  
+
 ```{r}
-head(iris) %>% rtf_body() %>%                       # Step 1 Add attributes 
-               rtf_encode() %>%                     # Step 2 Convert attributes to RTF encode 
-               write_rtf(file = "rtf/ex-tbl.rtf")   # Step 3 Write to a .rtf file 
+head(iris) %>%
+  rtf_body() %>% # Step 1 Add attributes
+  rtf_encode() %>% # Step 2 Convert attributes to RTF encode
+  write_rtf(file = "rtf/ex-tbl.rtf") # Step 3 Write to a .rtf file
 ```
 
 ```{r, out.width = "100%", out.height = "400px", echo = FALSE, fig.align = "center"}
@@ -52,61 +52,58 @@ knitr::include_graphics("pdf/ex-tbl.pdf")
 
 Similar step is used to create a figure. First we generate a figure in `png` format, then use `rtf_read_figure()` to read in the `png` file, and proceed to rtf generation.
 
-
 ```{r}
 fig <- c("fig/fig1.png")
-fig %>% rtf_read_figure() %>%                  # Step 1 Read in png file
-         rtf_figure() %>%                      # Step 2 Add attributes 
-         rtf_encode(doc_type = "figure") %>%   # Step 3 Convert attributes to RTF encode 
-         write_rtf(file = "rtf/ex-fig.rtf")           # Step 4 Write to a .rtf file 
+fig %>% rtf_read_figure() %>% # Step 1 Read in PNG file
+  rtf_figure() %>% # Step 2 Add attributes
+  rtf_encode(doc_type = "figure") %>% # Step 3 Convert attributes to RTF encode
+  write_rtf(file = "rtf/ex-fig.rtf") # Step 4 Write to a .rtf file
 ```
 
 ```{r, out.width = "100%", out.height = "400px", echo = FALSE, fig.align = "center"}
 knitr::include_graphics("pdf/ex-fig.pdf")
 ```
 
+## Data Structure and Attributes
 
-## Data Structure and Attributes 
-
-We explore `rtf_page()` to illustrate how attributes of a data frame is used. 
-`rtf_page()` is a function to define the feature of a page in rtf document. 
-For example, we need to set the page orientation, width, height, margin etc. 
-The information is attached to an data frame using attributes. 
+We explore `rtf_page()` to illustrate how attributes of a data frame is used.
+`rtf_page()` is a function to define the feature of a page in rtf document.
+For example, we need to set the page orientation, width, height, margin etc.
+The information is attached to an data frame using attributes.
 
 Therefore, the core part of `rtf_page()` is to assign attributes to the input data frame (`tbl`) as below.
 Necessary input checking using `check_arg()`, `stopifnot()` and `match.arg()`, is provided in the function to provide informative error message with unexpected input.
 
 ```{r, eval = FALSE}
-attr(tbl, "page")$orientation   <- orientation
-attr(tbl, "page")$width         <- width
-attr(tbl, "page")$height        <- height
-attr(tbl, "page")$margin        <- margin
+attr(tbl, "page")$orientation <- orientation
+attr(tbl, "page")$width <- width
+attr(tbl, "page")$height <- height
+attr(tbl, "page")$margin <- margin
 attr(tbl, "page")$border_color_first <- border_color_first
 ```
 
-All attributes is saved in a logical way and summarized in the table below.  
+All attributes is saved in a logical way and summarized in the table below.
 
 ```{r}
 tbl <- head(iris) %>% rtf_page()
 ```
 
-To access the attributes, `attr()` or `attributes()` function can be used. For example, to get page attributes 
-in default setting, we can run code below. 
+To access the attributes, `attr()` or `attributes()` function can be used. For example, to get page attributes
+in default setting, we can run code below.
 
 ```{r}
 data.frame(value = unlist(attr(tbl, "page")))
 ```
 
+The table body attributes are more complicated than page attributes. Take `rtf_body()` as an example, it meets
+the user's need to take fully control of table appearance through parameters to customize table size, space, border
+type (e.g., single, double, dash, dot, etc.), color (e.g., 657 different colors named in `color()` function),
+line width, column width, row height, text format (e.g., bold, italics, strikethrough, underline and any combinations),
+font size, text color, alignment (e.g., left, right, center, decimal), etc. Format control can be at the cell, row,
+column, or table level.
 
-The table body attributes are more complicated than page attributes. Take `rtf_body()` as an example, it meets 
-the user's need to take fully control of table appearance through parameters to customize table size, space, border 
-type (e.g., single, double, dash, dot, etc.), color (e.g., 657 different colors named in `color()` function), 
-line width, column width, row height, text format (e.g., bold, italics, strikethrough, underline and any combinations), 
-font size, text color, alignment (e.g., left, right, center, decimal), etc. Format control can be at the cell, row, 
-column, or table level. 
-
-With the help of functions `obj_rtf_text()` and `obj_rtf_border()`, it is straightforward to pass the user inputs to 
-text/border attributes. For example, parameter `text_justification = "c"` sets all text in the cells to be center adjusted 
+With the help of functions `obj_rtf_text()` and `obj_rtf_border()`, it is straightforward to pass the user inputs to
+text/border attributes. For example, parameter `text_justification = "c"` sets all text in the cells to be center adjusted
 and `text_justification = c("c", rep("l", 4))` sets the text in the first column to be center adjusted
 and the texts in the remaining 4 columns to be left adjusted for a table with five columns.
 
@@ -116,43 +113,44 @@ In addition, `rtf_body()` initiates "page" attributes when color is used in any 
 head(iris) %>% rtf_body()
 ```
 
-Similarly to `rtf_body()`, the package also includes 
-`rtf_colheader()`, `rtf_footnote()`, `rtf_source()`, `rtf_subline()`, `rtf_text()`, `rtf_title()` and `rtf_figure()` to 
-assign attributes to the certain component of the output. Below is a simple 
+Similarly to `rtf_body()`, the package also includes
+`rtf_colheader()`, `rtf_footnote()`, `rtf_source()`, `rtf_subline()`, `rtf_text()`, `rtf_title()` and `rtf_figure()` to
+assign attributes to the certain component of the output. Below is a simple
 example of using the functions together for table/figure.
 
 ```{r, eval = FALSE}
-head(iris) %>%                               # Step 1 Read in data frame
-  rtf_title("iris") %>%                      # Step 2 Add title
-  rtf_colheader("A | B | C | D | E") %>%     # Step 3 Add column header
-  rtf_body() %>%                             # Step 4 Add attributes 
-  rtf_footnote("This is a footnote") %>%     # Step 5 Add footnote 
-  rtf_source("Source: xxx")                  # Step 6 Add data source
+head(iris) %>% # Step 1 Read in data frame
+  rtf_title("iris") %>% # Step 2 Add title
+  rtf_colheader("A | B | C | D | E") %>% # Step 3 Add column header
+  rtf_body() %>% # Step 4 Add attributes
+  rtf_footnote("This is a footnote") %>% # Step 5 Add footnote
+  rtf_source("Source: xxx") # Step 6 Add data source
 ```
 
 ```{r, eval = FALSE}
 "fig/tmp-fig.png" %>%
-  rtf_read_figure() %>%                  # Step 1 Read PNG files from the file path
-  rtf_title("title", "subtitle") %>%     # Step 2 Add title or subtitle
-  rtf_footnote("footnote") %>%           # Step 3 Add footnote
+  rtf_read_figure() %>% # Step 1 Read PNG files from the file path
+  rtf_title("title", "subtitle") %>% # Step 2 Add title or subtitle
+  rtf_footnote("footnote") %>% # Step 3 Add footnote
   rtf_source("[datasource: mk0999]") %>% # Step 4 Add data source
-  rtf_figure()                           # Step 5 Add figure attributes 
+  rtf_figure() # Step 5 Add figure attributes
 ```
 
-## RTF Encoding 
+## RTF Encoding
 
-`rtf_encode()` wraps up internal functions in r2rtf package to translate all attributes attached to a data frame 
-into [RTF syntax](http://www.snake.net/software/RTF/RTF-Spec-1.7.pdf). 
+`rtf_encode()` wraps up internal functions in r2rtf package to translate all attributes attached to a data frame
+into [RTF syntax](http://www.snake.net/software/RTF/RTF-Spec-1.7.pdf).
 A good reference is [RTF pocket guide](https://www.oreilly.com/library/view/rtf-pocket-guide/9781449302047/).
 
-All of the internal encoding functions in r2rtf package start with a prefix `as_rtf_`. 
-For a table, `r2rtf:::rtf_encode_table()` is used internally to translate attribute to RTF syntax by using 
-a set of `as_rtf_` functions. 
+All of the internal encoding functions in the r2rtf package start with a prefix `as_rtf_`.
+For a table, `r2rtf:::rtf_encode_table()` is used internally to translate attribute to RTF syntax by using
+a set of `as_rtf_` functions.
 
-Likewise, `rtf_encode_list()` is used when we have multiple data frame with different data structures to be stacked, 
+Likewise, `rtf_encode_list()` is used when we have multiple data frame with different data structures to be stacked,
 this is often seen in efficacy analysis. And `rtf_encode_figure()` is used for figure outputs.
 
 `r2rtf:::as_rtf_colheader()` define the column header in a table or listing.
+
 ```{r, eval = FALSE}
 head(iris) %>%
   rtf_body() %>%
@@ -161,6 +159,7 @@ head(iris) %>%
 ```
 
 `r2rtf:::as_rtf_color()` define the color to be used in text or border.
+
 ```{r, eval = FALSE}
 head(iris) %>%
   rtf_body(text_color = "red") %>%
@@ -169,16 +168,19 @@ head(iris) %>%
 ```
 
 `r2rtf:::as_rtf_end()` define the end of rtf encode string.
+
 ```{r, eval = FALSE}
 r2rtf:::as_rtf_end() %>% cat()
 ```
 
 `r2rtf:::as_rtf_font()` define the font encode.
+
 ```{r, eval = FALSE}
 r2rtf:::as_rtf_font() %>% cat()
 ```
 
 `r2rtf:::as_rtf_footnote()` define the footnote encode.
+
 ```{r}
 head(iris) %>%
   rtf_footnote("example") %>%
@@ -186,12 +188,14 @@ head(iris) %>%
   cat()
 ```
 
-`r2rtf:::as_rtf_init()` initiates rtf encode with 'English' as default language.
+`r2rtf:::as_rtf_init()` initiates rtf encode with 'English' as the default language.
+
 ```{r, eval = FALSE}
 r2rtf:::as_rtf_init() %>% cat()
 ```
 
-`r2rtf:::as_rtf_margin()` define a page margin. 
+`r2rtf:::as_rtf_margin()` define a page margin.
+
 ```{r, eval = FALSE}
 head(iris) %>%
   rtf_page() %>%
@@ -199,12 +203,14 @@ head(iris) %>%
   cat()
 ```
 
-`r2rtf:::as_rtf_new_page()` initiates new page encode. 
+`r2rtf:::as_rtf_new_page()` initiates new page encode.
+
 ```{r, eval = FALSE}
 r2rtf::as_rtf_new_page() %>% cat()
 ```
 
 `r2rtf:::as_rtf_page()` define a page width (`\paperw`) and height(`\paperh`).
+
 ```{r, eval = FALSE}
 head(iris) %>%
   rtf_page() %>%
@@ -213,6 +219,7 @@ head(iris) %>%
 ```
 
 `r2rtf:::as_rtf_pageby()` define a page_by encoding when argument page_by is not NULL in `rtf_body()`.
+
 ```{r, eval = FALSE}
 iris %>%
   rtf_body(page_by = "Species") %>%
@@ -221,11 +228,13 @@ iris %>%
 ```
 
 `r2rtf:::as_rtf_paragraph()` define a title/text attribute as paragraph.
+
 ```{r, eval = FALSE}
 r2rtf:::as_rtf_paragraph(attr(head(iris) %>% rtf_title("example"), "rtf_title")) %>% cat()
 ```
 
 `r2rtf:::as_rtf_source()` define the source encode.
+
 ```{r, eval = FALSE}
 head(iris) %>%
   rtf_source("example") %>%
@@ -234,6 +243,7 @@ head(iris) %>%
 ```
 
 `r2rtf:::as_rtf_subline()` define the subline encode.
+
 ```{r, eval = FALSE}
 head(iris) %>%
   rtf_subline("example") %>%
@@ -242,6 +252,7 @@ head(iris) %>%
 ```
 
 `r2rtf:::as_rtf_table()` define the table encode.
+
 ```{r, eval = FALSE}
 head(iris) %>%
   rtf_title("example") %>%
@@ -250,6 +261,7 @@ head(iris) %>%
 ```
 
 `r2rtf:::as_rtf_title()` define the title encode.
+
 ```{r, eval = FALSE}
 head(iris) %>%
   rtf_title("example") %>%
@@ -274,30 +286,30 @@ paste(
 ) %>% cat()
 ```
 
-If we save the RTF code into an `.rtf` file. 
+If we save the RTF code into an `.rtf` file.
 Microsoft Word or other RTF Viewer software can display the file properly.
-
 
 ## Save RTF File
 
-After everything has been translated into RTF code using `rtf_encode`. It is a simple step to save all RTF code 
-into an `.rtf` file. 
+After everything has been translated into RTF code using `rtf_encode()`. It is a simple step to save all RTF code
+into an `.rtf` file.
 
-`write_rtf()` is a simple wrap up of `write` function, which exports a single RTF string into the output file.
+`write_rtf()` is a simple wrapper of the `write()` function, which exports a single RTF string into the output file.
 
 A simple example is as in the overview section.
 
 ```{r, eval = FALSE}
-head(iris) %>% rtf_body() %>% # Step 1 Add attributes
+head(iris) %>%
+  rtf_body() %>% # Step 1 Add attributes
   rtf_encode() %>% # Step 2 Convert attributes to RTF encode
   write_rtf(file = "tmp.rtf") # Step 3 Write to a .rtf file
 ```
 
 ## Dictionary and Conversion
 
-As mentioned earlier, functions in `dictionary.R` file contains the most commonly used font types, formats, border types, etc. 
-All these attributes are mapped in a data frame which contains the element names and corresponding RTF encode. User is only 
-allowed to key in whatever is defined in dictionary for the rtf_ functions, or error message will be provided as a result from `match_arg()`. 
+As mentioned earlier, functions in the `dictionary.R` file contains the most commonly used font types, formats, border types, etc.
+All these attributes are mapped in a data frame which contains the element names and corresponding RTF encode. User is only
+allowed to key in whatever is defined in dictionary for the rtf_ functions, or error message will be provided as a result from `match_arg()`.
 
 ```{r}
 r2rtf:::font_type()
@@ -309,10 +321,10 @@ Superscripts, under scripts are taken care of by using `convert()` function to t
 r2rtf:::convert(c("^", "<="))
 ```
 
-## Pageby 
+## Pageby
 
-It is commonly seen a variable displayed in headline as group category (e.g. baseline characteristic table). 
-To achieve this, user first need to sort input data frame by page_by variable then define it in `rtf_body()`. 
+It is commonly seen a variable displayed in headline as group category (e.g. baseline characteristic table).
+To achieve this, user first need to sort input data frame by page_by variable then define it in `rtf_body()`.
 Border and text attributes are controlled together with other variables in the vectors.
 
 ```{r, eval = FALSE}
@@ -330,13 +342,10 @@ iris %>%
   write_rtf("pageby.rtf")
 ```
 
-
 ## Utility functions
 
-* `check_args()`: Function for argument checking for types, length or dimension, this function is used for all export functions except `write_rtf()`.
-* `match_arg()`: Function for argument verification on input values to see whether they match `dictionary()` defined values, 
+- `check_args()`: Function for argument checking for types, length or dimension, this function is used for all export functions except `write_rtf()`.
+- `match_arg()`: Function for argument verification on input values to see whether they match `dictionary()` defined values,
 this function is used for all export functions except `write_rtf`().
-* 'footnote_source_space()`: Function to derive space adjustment, whose results could be used in `rtf_footnote()` and `rtf_source()` 
+- `footnote_source_space()`: Function to derive space adjustment, whose results could be used in `rtf_footnote()` and `rtf_source()`
 when indentation is defined by user.
-    
- 

--- a/vignettes/example-ae-summary.Rmd
+++ b/vignettes/example-ae-summary.Rmd
@@ -10,12 +10,15 @@ output:
 
 ```{r setup, include=FALSE}
 knitr::opts_chunk$set(echo = TRUE)
+```
+
+```{r, message=FALSE, warning=FALSE}
 library(r2rtf)
 library(dplyr)
 library(tidyr)
 ```
 
-# Example:
+## Example
 
 This example shows how to create a simplified adverse events summary table as below.
 
@@ -23,7 +26,7 @@ This example shows how to create a simplified adverse events summary table as be
 knitr::include_graphics("pdf/ae_example.pdf")
 ```
 
-## Step 1: Create data for RTF table
+### Step 1: Create data for RTF table
 
 ```{r}
 data(r2rtf_adae)
@@ -46,7 +49,7 @@ ae_t1 <- r2rtf_adae %>%
 knitr::kable(ae_t1)
 ```
 
-## Step 2: Define table format
+### Step 2: Define table format
 
 ```{r}
 ae_tbl <- ae_t1 %>%
@@ -74,7 +77,7 @@ ae_tbl <- ae_t1 %>%
   rtf_source("Source: xxx")
 ```
 
-## Step 3: Output
+### Step 3: Output
 
 ```{r}
 # Output .rtf file

--- a/vignettes/example-basechar.Rmd
+++ b/vignettes/example-basechar.Rmd
@@ -10,12 +10,15 @@ output:
 
 ```{r setup, include=FALSE}
 knitr::opts_chunk$set(echo = TRUE)
+```
+
+```{r, message=FALSE, warning=FALSE}
 library(r2rtf)
 library(dplyr)
 library(tidyr)
 ```
 
-# Example:
+## Example
 
 This example shows how to create a baseline characteristic table as below.
 
@@ -23,7 +26,7 @@ This example shows how to create a baseline characteristic table as below.
 knitr::include_graphics("pdf/bs_example.pdf")
 ```
 
-## Step 1: Define utility functions
+### Step 1: Define utility functions
 
 We defined two utility functions for analysis purpose. 
 
@@ -124,7 +127,7 @@ bs_continous <- function(data, grp, var,
 }
 ```
 
-## Step 2: Create data for rtf table
+### Step 2: Create data for rtf table
 
 - Convert variable to factors to properly define display order
 
@@ -169,7 +172,7 @@ bs_tb[is.na(bs_tb)] <- "" # convert NA to blank string.
 knitr::kable(bs_tb)
 ```
 
-## Step 3: Define table format
+### Step 3: Define table format
 
 - page_by feature was used to display 3 parts (Gender, Age, Race) clearly
   + if using `new_page = TRUE` in `rtb_body()`, the 3 parts will be outputted into 3 pages
@@ -200,7 +203,7 @@ bs_rtf <- bs_tb %>%
   rtf_source("Source: xxx")
 ```
 
-## Step 4: Output
+### Step 4: Output
 
 ```{r}
 # Output .rtf file

--- a/vignettes/example-efficacy.Rmd
+++ b/vignettes/example-efficacy.Rmd
@@ -10,13 +10,16 @@ output:
 
 ```{r setup, include=FALSE}
 knitr::opts_chunk$set(echo = TRUE)
+```
+
+```{r, message=FALSE, warning=FALSE}
 library(r2rtf)
 library(dplyr)
 library(tidyr)
 library(emmeans)
 ```
 
-# Example:
+## Example
 
 This example shows how to create a efficacy table as below.
 
@@ -24,7 +27,7 @@ This example shows how to create a efficacy table as below.
 knitr::include_graphics("pdf/efficacy_example.pdf")
 ```
 
-## Step 1: Define some utility functions
+### Step 1: Define some utility functions
 
 - Format Model Estimator
 ```{r}
@@ -45,6 +48,7 @@ fmt_est <- function(data, columns = c("mean", "sd"), decimals = c(1, 2)) {
 ```
 
 - Format Confidence Interval
+
 ```{r}
 #' @noRd
 fmt_ci <- function(data, columns = c("lower.CL", "upper.CL"), decimals = 2) {
@@ -55,6 +59,7 @@ fmt_ci <- function(data, columns = c("lower.CL", "upper.CL"), decimals = 2) {
 ```
 
 - Format P-Value
+
 ```{r}
 #' @noRd
 fmt_pval <- function(data, columns = "p.value", decimals = 3) {
@@ -66,9 +71,9 @@ fmt_pval <- function(data, columns = "p.value", decimals = 3) {
 }
 ```
 
-## Step 2: ANCOVA analysis for HOMA data
+### Step 2: ANCOVA analysis for HOMA data
 
-The data is available at [https://missingdata.lshtm.ac.uk/dia-working-group/example-data-sets/](https://missingdata.lshtm.ac.uk/dia-working-group/example-data-sets/)
+The data is available at <https://missingdata.lshtm.ac.uk/dia-working-group/example-data-sets/>.
 
 - Read in data and run ANCOVA model
 
@@ -98,7 +103,7 @@ t11 <- HAMD17 %>%
   )
 ```
 
-- LS mean 
+- LS means
 
 ```{r}
 t12 <- emmeans(HAMD17_lmfit, "TRT")
@@ -156,7 +161,7 @@ t3 <- data.frame(rmse = paste0(
 knitr::kable(t3)
 ```
 
-## Step 3: Define table format
+### Step 3: Define table format
 
 The table consists of three data frames: `t1`, `t2`, and `t3`. We define each data frame's format as below then combine them into a listing. 
 
@@ -218,7 +223,7 @@ tbl <- list(tbl_1, tbl_2, tbl_3)
 knitr::kable(tbl)
 ```
 
-## Step 4: Output
+### Step 4: Output
 
 ```{r}
 # Output .rtf file

--- a/vignettes/example-figure.Rmd
+++ b/vignettes/example-figure.Rmd
@@ -10,12 +10,15 @@ output:
 
 ```{r setup, include=FALSE}
 knitr::opts_chunk$set(echo = TRUE)
+```
+
+```{r, message=FALSE, warning=FALSE}
 library(r2rtf)
 library(dplyr)
 library(tidyr)
 ```
 
-# Examples:
+## Examples
 
 This example shows how to create and embed figures into an RTF file as below.
 
@@ -29,7 +32,7 @@ Below is an example with adjusted page orientation, figure height and width.
 knitr::include_graphics("pdf/fig-landscape.pdf")
 ```
 
-## Overall workflow
+### Overall workflow
 
 The package allow user to embed multiple figures into one RTF document. 
 The supported format is listed as below. 
@@ -38,26 +41,25 @@ The supported format is listed as below.
 r2rtf:::fig_format()
 ```
 
-
 By using `png` file as an example, the workflow can be summarized as:
 
-1. save figures into PNG format. (e.g. using `png()` or `ggplot2::ggsave()`).
-1. read PNG files into R as binary file using `r2rtf::rtf_read_figure()`.
-1. add optional features using `r2rtf::rtf_title()`, `r2rtf::rtf_footnote()`, `r2rtf::rtf_source()`.
-1. set up page and figure options using `r2rtf::rtf_page()`, `r2rtf::rtf_figure()`.
-1. encode rtf using `r2rtf::rtf_encode(doc_type = "figure")`. (Note: it is important to set `doc_type = "figure")` as the default is `doc_type = "table` to handle tables).
-1. write rtf to a file using `r2rtf::write_rtf`.
+1. Save figures into PNG format. (e.g. using `png()` or `ggplot2::ggsave()`).
+1. Read PNG files into R as binary file using `r2rtf::rtf_read_figure()`.
+1. Add optional features using `r2rtf::rtf_title()`, `r2rtf::rtf_footnote()`, `r2rtf::rtf_source()`.
+1. Set up page and figure options using `r2rtf::rtf_page()`, `r2rtf::rtf_figure()`.
+1. Encode rtf using `r2rtf::rtf_encode(doc_type = "figure")`. (Note: it is important to set `doc_type = "figure"` as the default is `doc_type = "table` to handle tables).
+1. Write rtf to a file using `r2rtf::write_rtf()`.
 
-> For `emf` format, one may use the `devEMF` R package to create the figure. 
+> For `emf` format, one may use the R package `devEMF` to create the figure. 
 
-### Simple Example
+#### Simple Example
 
 ```{r}
 # Define the path of figure
 filename <- c("fig/fig1.png", "fig/fig2.png", "fig/fig3.png")
 
 filename %>%
-  rtf_read_figure() %>%                     # read PNG files from the file path
+  rtf_read_figure() %>%                  # read PNG files from the file path
   rtf_title("title", "subtitle") %>%     # add title or subtitle
   rtf_footnote("footnote") %>%           # add footnote
   rtf_source("[datasource: mk0999]") %>% # add data source
@@ -66,7 +68,7 @@ filename %>%
   write_rtf(file = "rtf/fig-simple.rtf") # write RTF to a file
 ```
 
-### Example with features
+#### Example with features
 
 Features of page and figure can be set up in `rtf_page` and `rtf_figure` respectively: 
 
@@ -78,7 +80,7 @@ The code below provides an example for these features.
 
 ```{r}
 filename %>%
-  rtf_read_figure() %>%                                # read PNG files from the file path
+  rtf_read_figure() %>%                             # read PNG files from the file path
   rtf_page(orientation = "landscape") %>%           # set page orientation
   rtf_title("title", "subtitle") %>%                # add title or subtitle
   rtf_footnote("footnote") %>%                      # add footnote

--- a/vignettes/example-sublineby-pageby-groupby.Rmd
+++ b/vignettes/example-sublineby-pageby-groupby.Rmd
@@ -10,28 +10,31 @@ output:
 
 ```{r setup, include=FALSE}
 knitr::opts_chunk$set(echo = TRUE)
+```
+
+```{r, message=FALSE, warning=FALSE}
 library(r2rtf)
 library(dplyr)
 library(tidyr)
 ```
 
-# Overview
+## Overview
 
-In `rtf_body`, `r2rtf` provided three advanced arguments to customize table layout. 
+In `rtf_body()`, `r2rtf` provided three advanced arguments to customize table layout. 
 
 - `page_by`: The variable is used as section header.   
 - `group_by`: The variable only display when it is first appeared. 
 - `subline_by`: The variable is used as page subline header.
 
-If one or more of the arugments are used, they need to be properly ordered 
+If one or more of the arguments are used, they need to be properly ordered 
 in `subline_by`, `page_by` and `group_by`. 
 
 For `page_by`, the argument `new_page` and `pageby_header` and `pageby_row` further 
-customize the table layout. Details can be found in the `rtf_body` documentation. 
+customize the table layout. Details can be found in the `rtf_body()` documentation. 
 
 We provided three examples below to illustrate the idea. 
 
-# Example 1: Pageby 
+## Example 1: Pageby 
 
 We used `page_by` variable to illustrate how to create a simple disposition table. 
 
@@ -42,7 +45,7 @@ We used `page_by` variable to illustrate how to create a simple disposition tabl
 knitr::include_graphics("pdf/pageby-disposition.pdf")
 ```
 
-## Step 1: Create data for RTF table
+### Step 1: Create data for RTF table
 
 ```{r}
 data(r2rtf_adsl)
@@ -109,7 +112,7 @@ ds[is.na(ds)] <- 0
 knitr::kable(head(ds))
 ```
 
-## Step 2: Define table format
+### Step 2: Define table format
 
 ```{r}
 ds_tbl <- ds %>%
@@ -135,7 +138,7 @@ ds_tbl <- ds %>%
   rtf_source("Source:  [Study MK9999P001: adam-adsl]")
 ```
 
-## Step 3: Output
+### Step 3: Output
 
 ```{r}
 # Output .rtf file
@@ -144,7 +147,7 @@ ds_tbl %>%
   write_rtf("rtf/pageby-disposition.rtf")
 ```
 
-# Example 2: Pageby with `pageby_row = "first_row"` 
+## Example 2: Pageby with `pageby_row = "first_row"` 
 
 We used `page_by` variable and `pageby_row = "first_row"` to illustrate 
 how to create a simple adverse events table. 
@@ -153,7 +156,7 @@ how to create a simple adverse events table.
 knitr::include_graphics("pdf/pageby-firstrow-ae.pdf")
 ```
 
-## Step 1: Create data for RTF table 
+### Step 1: Create data for RTF table 
 
 ```{r, message=FALSE}
 # Read in and merge r2rtf_adsl and r2rtf_adae data
@@ -220,7 +223,7 @@ apr0ae <- bind_rows(part1, blank, part2)
 knitr::kable(head(apr0ae))
 ```
 
-## Step 2: Define table format
+### Step 2: Define table format
 
 ```{r}
 apr0ae_rtf <- apr0ae %>%
@@ -246,7 +249,7 @@ apr0ae_rtf <- apr0ae %>%
   rtf_source("Source:  [Study MK9999P001: adam-adae]")
 ```
 
-## Step 3: Output
+### Step 3: Output
 
 ```{r}
 # Output .rtf file
@@ -255,7 +258,7 @@ apr0ae_rtf %>%
   write_rtf("rtf/pageby-firstrow-ae.rtf")
 ```
 
-# Example 3: sublineby, pageby, and groupby features
+## Example 3: sublineby, pageby, and groupby features
 
 We used `page_by`, `subline_by` and `group_by` to illustrate 
 how to create a simple adverse events listing. 
@@ -264,7 +267,7 @@ how to create a simple adverse events listing.
 knitr::include_graphics("pdf/pageby-ae-listing.pdf")
 ```
 
-## Step 1: Create data for RTF table
+### Step 1: Create data for RTF table
 
 ```{r}
 data(r2rtf_adae)
@@ -294,7 +297,7 @@ ae_t1 <- r2rtf_adae[200:260, ] %>%
 knitr::kable(head(ae_t1, 2))
 ```
 
-## Step 2: Define table format
+### Step 2: Define table format
 
 ```{r}
 ae_tbl <- ae_t1 %>%
@@ -329,7 +332,7 @@ ae_tbl <- ae_t1 %>%
   rtf_source("Source:  [Study MK9999P001: adam-adae]")
 ```
 
-## Step 3: Output
+### Step 3: Output
 
 ```{r}
 # Output .rtf file

--- a/vignettes/r2rtf-cran.Rmd
+++ b/vignettes/r2rtf-cran.Rmd
@@ -9,7 +9,7 @@ vignette: >
   %\VignetteEngine{knitr::rmarkdown}
 ---
 
-Please see https://merck.github.io/r2rtf/articles/index.html for the full documentation. Here is only a minimal example:
+Please see <https://merck.github.io/r2rtf/articles/index.html> for the full documentation. Here is only a minimal example:
 
 ```{r, eval = FALSE}
 library(dplyr)

--- a/vignettes/r2rtf.Rmd
+++ b/vignettes/r2rtf.Rmd
@@ -5,56 +5,57 @@ output:
     df_print: paged
     toc: yes
     toc_depth: '2'
-description: > 
-  Start here if this is your first time using r2rtf. 
-  You'll learn the basic philosophy, the most important rtf table generation verbs. 
+description: >
+  Start here if this is your first time using r2rtf.
+  You'll learn the basic philosophy, the most important rtf table generation verbs.
 ---
 
 ```{r setup, include=FALSE}
 knitr::opts_chunk$set(echo = TRUE, collapse = TRUE)
-library(r2rtf)
-library(ggplot2)
-library(dplyr)
-library(tidyr)
 ```
 
 ## Overview
 
 `r2rtf` is an R package to create production ready tables and figures in RTF format.
-The R package is designed to 
+The R package is designed to
 
-- provide simple "verb" functions that correspond to each component of a table, 
+- provide simple "verb" functions that correspond to each component of a table,
   to help you translate data frame to table in RTF file.
-- enable pipes (`%>%`). 
-- only focus on **table format**. 
-  Data manipulation and analysis shall be handled by other R packages. (e.g. `tidyverse`)
-- `r2rtf` minimizes package dependency 
+- enable pipes (`%>%`).
+- only focus on **table format**.
+  Data manipulation and analysis should be handled by other R packages. (e.g., `tidyverse`)
+- `r2rtf` minimizes package dependency
 
 Before creating an RTF table we need to:
 
-- Figure out table layout. 
-
+- Figure out table layout.
 - Split the layout into small tasks in the form of a computer program.
-
 - Execute the program.
 
-This document introduces `r2rtf` basic set of tools, and show how to transfer 
+This document introduces `r2rtf` basic set of tools, and show how to transfer
 data frames into Table, Listing, and Figure (TLFs).
 
-Other extended examples and features are covered in different document listed in 
-[table of content](https://merck.github.io/r2rtf/articles/index.html). 
+Other extended examples and features are covered in different document listed in
+[vignettes](https://merck.github.io/r2rtf/articles/index.html).
 
 ## Data: Adverse Events
 
-To explore the basic RTF generation verbs in `r2rtf`, we'll use the dataset `r2rtf_adae`. 
+To explore the basic RTF generation verbs in `r2rtf`, we will use the dataset `r2rtf_adae`.
 This dataset contain adverse events (AE) information from a clinical trial.
 
-Below is the meaning of relevant variables. 
+Below is the meaning of relevant variables.
 More information can be found in help page of the dataset (`?r2rtf_adae`)
 
 - USUBJID: Unique Subject Identifier
-- TRTA: Actual Treatment 
+- TRTA: Actual Treatment
 - AEDECOD: Dictionary-Derived Term
+
+```{r, message=FALSE, warning=FALSE}
+library(r2rtf)
+library(ggplot2)
+library(dplyr)
+library(tidyr)
+```
 
 ```{r}
 r2rtf_adae %>%
@@ -64,12 +65,12 @@ r2rtf_adae %>%
 
 ## Table ready data
 
-`dplyr` and `tidyr` packages are used for data manipulation to create a data frame 
-that contains all the information we want to add in an RTF table. 
+`dplyr` and `tidyr` packages are used for data manipulation to create a data frame
+that contains all the information we want to add in an RTF table.
 
 > Please note other packages can also be used for the same purpose.
 
-In this AE example, we provide number of subjects with each type of AE by treatment group. 
+In this AE example, we provide number of subjects with each type of AE by treatment group.
 
 ```{r}
 tbl <- r2rtf_adae %>%
@@ -92,13 +93,13 @@ tbl %>% head(4)
 All these verbs is designed to enables usage of pipes (`%>%`).
 A full list of all functions can be found in [package reference](https://merck.github.io/r2rtf/reference/index.html)
 
-## Simple Example 
+## Simple Example
 
 A minimal example below illustrates how to combine verbs using pipes to create an RTF table.
 
-- `rtf_body` is used to define table body layout. 
-- `rtf_encode` transfers table layout information into RTF syntax.
-- `write_rtf` save RTF encoding into a file with file extension `.rtf` 
+- `rtf_body()` is used to define table body layout.
+- `rtf_encode()` transfers table layout information into RTF syntax.
+- `write_rtf()` save RTF encoding into a file with file extension `.rtf`.
 
 ```{r}
 head(tbl) %>%
@@ -111,17 +112,17 @@ head(tbl) %>%
 knitr::include_graphics("pdf/intro-ae1.pdf")
 ```
 
-## Column Width 
+## Column Width
 
-If we want to adjust the width of each column to provide more space to the first column, 
+If we want to adjust the width of each column to provide more space to the first column,
 and this can be achieved by updating `col_rel_width` in `rtf_body`.
 
-The input of `col_rel_width` is a vector with same length for number of columns. 
-This argument defines the relative length of each column within a pre-defined total column width. 
+The input of `col_rel_width` is a vector with same length for number of columns.
+This argument defines the relative length of each column within a pre-defined total column width.
 
-In this example, the defined relative width is 3:2:2:2. 
-Only the ratio of `col_rel_width` is used. 
-Therefore it is equivalent to use `col_rel_width = c(6,4,4,4)` or `col_rel_width = c(1.5,1,1,1)`. 
+In this example, the defined relative width is 3:2:2:2.
+Only the ratio of `col_rel_width` is used.
+Therefore it is equivalent to use `col_rel_width = c(6,4,4,4)` or `col_rel_width = c(1.5,1,1,1)`.
 
 ```{r}
 head(tbl) %>%
@@ -135,18 +136,18 @@ head(tbl) %>%
 knitr::include_graphics("pdf/intro-ae2.pdf")
 ```
 
-Note: 
+Note:
 
-- The `col_rel_width` in `rtf_body` function only control relative width of table body. Therefore the column header is not aligned as expected. More details will be provided in next example to take care of column header width.
-- The total column width is defined in `col_width` argument of `rtf_page` function. 
+- The `col_rel_width` in the `rtf_body()` function only control relative width of table body. Therefore the column header is not aligned as expected. More details will be provided in next example to take care of column header width.
+- The total column width is defined in the `col_width` argument of the `rtf_page()` function.
 
-## Column Headers 
+## Column Headers
 
-In previous example, we found issue of misaligned column header. 
-We can fix the issue by using `rtf_colheader` function.
+In previous example, we found issue of misaligned column header.
+We can fix the issue by using the `rtf_colheader()` function.
 
-In `rtf_colheader`, `colheader` argument is used to provide content of column header. 
-We used `"|"` to separate the columns. 
+In `rtf_colheader`, `colheader` argument is used to provide content of column header.
+We used `"|"` to separate the columns.
 
 ```{r}
 head(tbl) %>%
@@ -163,13 +164,13 @@ head(tbl) %>%
 knitr::include_graphics("pdf/intro-ae3.pdf")
 ```
 
-We also allow column headers be displayed in multiple lines. 
-If an empty column name is needed for a column, you can insert a space between two vertical lines; e.g., `"name 1 | | name 3"`. 
+We also allow column headers be displayed in multiple lines.
+If an empty column name is needed for a column, you can insert a space between two vertical lines; e.g., `"name 1 | | name 3"`.
 
-The `col_rel_width` can be used to align column header with different number of columns. 
+The `col_rel_width` can be used to align column header with different number of columns.
 
-By using `rtf_colheader` with `col_rel_width`, one can customize complicated column headers. 
-If there are multiple pages, column header will repeat at each page by default. 
+By using `rtf_colheader` with `col_rel_width`, one can customize complicated column headers.
+If there are multiple pages, column header will repeat at each page by default.
 
 ```{r}
 head(tbl, 50) %>%
@@ -190,14 +191,14 @@ head(tbl, 50) %>%
 knitr::include_graphics("pdf/intro-ae4.pdf")
 ```
 
-## Text Alignment 
+## Text Alignment
 
-In `rtf_*` functions such as `rtf_body`, `rtf_footnote`, `text_justification` argument is used to align text. 
-Default is `"c"` for center justification. 
+In `rtf_*()` functions such as `rtf_body()`, `rtf_footnote()`, the `text_justification` argument is used to align text.
+Default is `"c"` for center justification.
 To vary text justification by column, use character vector with length of vector equal to
-number of columns displayed (e.g., `c("c","l","r")`). 
+number of columns displayed (e.g., `c("c","l","r")`).
 
-All possible inputs can be found in the first column of `r2rtf:::justification()`. 
+All possible inputs can be found in the first column of `r2rtf:::justification()`.
 
 ```{r}
 r2rtf:::justification()
@@ -216,11 +217,11 @@ head(tbl) %>%
 knitr::include_graphics("pdf/intro-ae5.pdf")
 ```
 
-## Text Style 
+## Text Style
 
-In `rtf_*` functions such as `rtf_body`, `rtf_footnote`, etc., 
-`text_format` argument is used for controlling text style. 
-Default is NULL for normal. 
+In `rtf_*()` functions such as `rtf_body()`, `rtf_footnote()`, etc.,
+the `text_format` argument is used for controlling text style.
+Default is `NULL` for normal.
 
 All possible inputs and corresponding text style can be found in `r2rtf:::font_format()`.
 
@@ -228,9 +229,9 @@ All possible inputs and corresponding text style can be found in `r2rtf:::font_f
 r2rtf:::font_format()
 ```
 
-Combination of format type are permitted as input (e.g., `"ub"` for bold and underlined text). 
-To vary text format by column, use character vector with length of vector equal to 
-number of columns displayed (e.g., `c("i", "u", "ib")`). 
+Combination of format type are permitted as input (e.g., `"ub"` for bold and underlined text).
+To vary text format by column, use character vector with length of vector equal to
+number of columns displayed (e.g., `c("i", "u", "ib")`).
 
 Below is an example to make first column in bold and normal for the rest.
 
@@ -245,16 +246,16 @@ head(tbl) %>%
 knitr::include_graphics("pdf/intro-ae6.pdf")
 ```
 
-## Table Border 
+## Table Border
 
-In `rtf_*` functions such as `rtf_body`, `rtf_footnote`, etc.,
-`border_left`, `border_right`, `border_top`, and `border_bottom` control border. 
+In `rtf_*()` functions such as `rtf_body()`, `rtf_footnote()`, etc.,
+`border_left`, `border_right`, `border_top`, and `border_bottom` control border.
 
-In example of `intro-ae4.rtf`, if we want to remove the top border of `"Adverse Events"` in header, 
-we can change default value `"single"` to `""` in `border_top` argument as showed below. 
+In example of `intro-ae4.rtf`, if we want to remove the top border of `"Adverse Events"` in header,
+we can change default value `"single"` to `""` in `border_top` argument as showed below.
 
-All possible border type inputs can be found in `r2rtf:::border_type()`. 
-There are 26 different border type, we only display first six here. 
+All possible border type inputs can be found in `r2rtf:::border_type()`.
+There are 26 different border type, we only display first six here.
 
 ```{r}
 head(r2rtf:::border_type())
@@ -283,13 +284,13 @@ knitr::include_graphics("pdf/intro-ae7.pdf")
 
 ## Title
 
-The title(s) can be added using the `rtf_title` function as showed in below example. 
-To get guidance on how to change title text style, aligning title, and other features in the `rtf_title` function, help page `?r2rtf::rtf_title()` is a good resource.
+The title(s) can be added using the `rtf_title()` function as showed in below example.
+To get guidance on how to change title text style, aligning title, and other features in the `rtf_title()` function, help page `?r2rtf::rtf_title()` is a good resource.
 
-We can provide a vector for the `title` argument. Each value is a separate line. 
+We can provide a vector for the `title` argument. Each value is a separate line.
 The format can also be controlled by providing a vector input in `text_format`.
 
-> We used soft return to break lines in title. 
+> We used soft return to break lines in title.
 
 ```{r}
 head(tbl) %>%
@@ -313,11 +314,11 @@ head(tbl) %>%
 knitr::include_graphics("pdf/intro-ae8.pdf")
 ```
 
-## Footnote 
+## Footnote
 
-The footnote(s) can be added using `footnote` argument in the `rtf_footnote` function as showed in below example.
+The footnote(s) can be added using `footnote` argument in the `rtf_footnote()` function as showed in below example.
 
-We can provide a vector for the `footnote` argument. Each value is a separate line. 
+We can provide a vector for the `footnote` argument. Each value is a separate line.
 
 Below example showed the case when using `as_table = TRUE` (default) to display footnote inside the table body.
 
@@ -371,11 +372,11 @@ knitr::include_graphics("pdf/intro-ae10.pdf")
 
 ## Data Source
 
-Data source can be added using `source` argument in the `rtf_source` function as showed in below example.
+Data source can be added using `source` argument in the `rtf_source()` function as showed in below example.
 
 Below example showed the case when using `as_table = FALSE` (default) to display data source outside the table body.
 
-> We can also adjust data source to be left aligned. By default the alignment matches the table border.  
+> We can also adjust data source to be left aligned. By default the alignment matches the table border.
 
 ```{r}
 head(tbl) %>%
@@ -422,19 +423,19 @@ head(tbl) %>%
 knitr::include_graphics("pdf/intro-ae12.pdf")
 ```
 
-## Special Character 
+## Special Character
 
-In the `r2rtf` package, `'^'` is a character to be converted to rtf code 
+In the `r2rtf` package, `'^'` is a character to be converted to rtf code
 `'\\super'` to generate superscript; `'_'` is for subscript.
 
-Similarly, `'<='` is a `r2rtf` package specified character to be converted to 
-LaTeX command `'\\leq'` to generate special character $\leq$. 
+Similarly, `'<='` is a `r2rtf` package specified character to be converted to
+LaTeX command `'\\leq'` to generate special character $\leq$.
 
-LaTeX commands can be used for Greek letters and math symbol such as $\alpha$, $\pm$, $\infty$. 
-You will need to use double backslash `\\` to escape backslash in R. i.e. `"\\alpha"`, `"\\pm"` and `"\\infty"`. 
-A list of LaTex commands can be found [here](https://www.overleaf.com/learn/latex/List_of_Greek_letters_and_math_symbols) 
+LaTeX commands can be used for Greek letters and math symbol such as $\alpha$, $\pm$, $\infty$.
+You will need to use double backslash `\\` to escape backslash in R. i.e. `"\\alpha"`, `"\\pm"` and `"\\infty"`.
+A list of LaTex commands can be found [here](https://www.overleaf.com/learn/latex/List_of_Greek_letters_and_math_symbols)
 
-Example below demonstrate the idea. 
+Example below demonstrate the idea.
 
 ```{r}
 head(tbl) %>%
@@ -462,15 +463,15 @@ knitr::include_graphics("pdf/intro-ae13.pdf")
 
 ## Table Color
 
-Each cell's text and background color are controllable. 
-Take `intro-ae13.rtf` as an example, if we want to add gray background color to cells with 0 AE, 
-we need to create a color name matrix corresponding to each cell in table body. 
+Each cell's text and background color are controllable.
+Take `intro-ae13.rtf` as an example, if we want to add gray background color to cells with 0 AE,
+we need to create a color name matrix corresponding to each cell in table body.
 
-Then assign this background color matrix to `text_background_color` argument in `rtf_body` function as showed below.  
+Then assign this background color matrix to `text_background_color` argument in the `rtf_body()` function as showed below.
 
 Note:
 
-- When creating a color name matrix, each element needs to be a color name defined in `grDevices::colours()`. 
+- When creating a color name matrix, each element needs to be a color name defined in `grDevices::colours()`.
 
 ```{r}
 tbl1 <- head(tbl)
@@ -499,7 +500,7 @@ knitr::include_graphics("pdf/intro-ae14.pdf")
 
 ## Page setup
 
-The total number of rows in each page can be controlled in `nrow` argument of `rtf_page` function.
+The total number of rows in each page can be controlled in `nrow` argument of `rtf_page()` function.
 Every lines is counted including title, subline, header, body, footnote, source, and extra rows.
 
 The value in `nrow` is the maximum of row allowed in one page, the actual rows display can be slightly smaller.
@@ -526,12 +527,12 @@ knitr::include_graphics("pdf/intro-ae15.pdf")
 
 ## subline_by feature
 
-Users can use `subline_by` argument in the `rtf_body` function to group table by assigned `subline_by` variable.
+Users can use the `subline_by` argument in the `rtf_body()` function to group table by assigning the `subline_by` variable.
 
-A subject line will be displayed at the beginning of each page based on the variable provided to `subline_by`. 
-Different value of `subline_by` will be break into different pages. 
+A subject line will be displayed at the beginning of each page based on the variable provided to `subline_by`.
+Different value of `subline_by` will be break into different pages.
 
-Below example showed using treatment group as `subline_by` variable. 
+Below example showed using treatment group as the `subline_by` variable.
 
 ```{r, message=FALSE}
 aegt5 <- r2rtf_adae %>%
@@ -559,13 +560,13 @@ knitr::include_graphics("pdf/intro-ae16.pdf")
 
 ## page_by feature
 
-Users can use `page_by` argument in the `rtf_body` function to group/separate table by single cell row with assigned `page_by` variable's value in it. 
+Users can use `page_by` argument in the `rtf_body()` function to group/separate table by single cell row with assigned `page_by` variable's value in it.
 
-A row header will be generated at the begining of each `page_by` group. 
+A row header will be generated at the beginning of each `page_by` group.
 
-if `new_page=TRUE`, different value of `group_by` will be break into different pages. Default is `FALSE`. 
+if `new_page = TRUE`, different value of `group_by` will be break into different pages. Default is `FALSE`.
 
-Below example showed using treatment group as `page_by` variable. 
+Below example showed using treatment group as `page_by` variable.
 
 ```{r}
 aegt5 %>%
@@ -585,9 +586,9 @@ knitr::include_graphics("pdf/intro-ae17.pdf")
 
 ## group_by feature
 
-Users can use `group_by` argument in the `rtf_body` function to display once for group variable. 
+Users can use the `group_by` argument in the `rtf_body()` function to display once for group variable.
 
-Below example showed using treatment group as `group_by` variable. 
+Below example showed using treatment group as `group_by` variable.
 
 ```{r}
 aegt5 %>%
@@ -607,16 +608,16 @@ knitr::include_graphics("pdf/intro-ae18.pdf")
 
 ## Figure
 
-The last example showed how to insert a figure into a RTF document. 
+The last example showed how to insert a figure into a RTF document.
 
 The workflow can be summarized as:
 
-- save figures into PNG format. (e.g. using `png()` or `ggplot2::ggsave()`).
-- read PNG files into R as binary file using `rtf_read_figure`.
-- add optional features using `rtf_title`, `rtf_footnote`, `rtf_source`.
-- set up page and figure options using `rtf_figure`.
-- convert to rtf encoding using `rtf_encode(doc_type = "figure")`. (Note: it is important to set `doc_type = "figure")` as the  default is `doc_type = "table` to set up tables).
-- write rtf to a file using `write_rtf`.
+- Save figures into PNG format. (e.g. using `png()` or `ggplot2::ggsave()`).
+- Read PNG files into R as binary file using `rtf_read_figure()`.
+- Add optional features using `rtf_title()`, `rtf_footnote()`, `rtf_source()`.
+- Set up page and figure options using `rtf_figure()`.
+- Convert to rtf encoding using `rtf_encode(doc_type = "figure")`. (Note: it is important to set `doc_type = "figure"` as the default is `doc_type = "table` to set up tables).
+- Write rtf to a file using `write_rtf()`.
 
 ```{r, message = FALSE}
 pruritus <- r2rtf_adae %>%
@@ -630,6 +631,7 @@ fig <- ggplot(data = pruritus, aes(x = TRTA, y = Count)) +
 
 fig
 ```
+
 ```{r}
 filename <- "fig/intro-fig1.png"
 ggsave(filename, fig)

--- a/vignettes/rtf-convert-format.Rmd
+++ b/vignettes/rtf-convert-format.Rmd
@@ -13,12 +13,14 @@ library(r2rtf)
 ```
 
 ```{r, include = FALSE, eval = FALSE}
-r2rtf:::rtf_convert_format(input = list.files("vignettes/rtf/", pattern = "*.rtf", full.names = TRUE), 
-                           output_dir = "vignettes/html", 
-                           format = "html")
+r2rtf:::rtf_convert_format(
+  input = list.files("vignettes/rtf/", pattern = "*.rtf", full.names = TRUE),
+  output_dir = "vignettes/html",
+  format = "html"
+)
 ```
 
-# Overview
+## Overview
 
 `r2rtf` had an experimental internal function `r2rtf:::rtf_convert_format` to 
 convert RTF format to PDF, DOCX or HTML. 
@@ -46,7 +48,7 @@ r2rtf:::rtf_convert_format(input = list.files("rtf", pattern = "*.rtf"))
 r2rtf:::rtf_convert_format(input = "rtf/ae_example.rtf", format = "html")
 ```
 
-## Limitations 
+### Limitations 
 
 There is one known limitation after RTF file convert to HTML files:   
 

--- a/vignettes/rtf-row.Rmd
+++ b/vignettes/rtf-row.Rmd
@@ -13,9 +13,7 @@ library(r2rtf)
 library(dplyr)
 ```
 
-
 This vignette documents how to use `.rtf_row` to customize table in details. All output tables are saved in the `vignettes/rtf` folder and assembled in `vignettes/r2rtf_examples.docx` document. 
-
 
 ## Border Type
 
@@ -27,7 +25,8 @@ r2rtf:::border_type()$name
 
 The border type can be used to define the top, left, right and bottom border types. 
 
-This example define different top border line. 
+This example define different top border line.
+
 ```{r}
 .n <- length(r2rtf:::border_type()$name)
 db <- data.frame(border_type = r2rtf:::border_type()$name) %>%
@@ -43,7 +42,6 @@ db %>%
 ```{r, out.width = "100%", out.height = "400px", echo = FALSE, fig.align = "center"}
 knitr::include_graphics("pdf/border-type.pdf")
 ```
-
 
 For each cell, the top border and left border is defined in each cell. The right border only defined in last column. 
 The bottom border only defined in last row. This example show that top border and left border type are used for all 
@@ -67,6 +65,7 @@ knitr::include_graphics("pdf/border-order.pdf")
 ```
 
 This example display table with specific border type (i.e. double line at the first and last line and blank at the middle)
+
 ```{r}
 rtf_db <- iris %>%
   head() %>%
@@ -84,7 +83,6 @@ rtf_db %>%
 ```{r, out.width = "100%", out.height = "400px", echo = FALSE, fig.align = "center"}
 knitr::include_graphics("pdf/border-example.pdf")
 ```
-
 
 * The first and last border of the whole table is controled by `border_first` and `border_last` argument in `rtf_page()`  
 
@@ -118,7 +116,6 @@ rtf_db %>%
   rtf_encode() %>%
   write_rtf("rtf/border-vector.rtf")
 ```
-
 
 ```{r, out.width = "100%", out.height = "400px", echo = FALSE, fig.align = "center"}
 knitr::include_graphics("pdf/border-vector.pdf")
@@ -156,7 +153,6 @@ db[, rep(1, 4)] %>%
 ```{r, out.width = "100%", out.height = "400px", echo = FALSE, fig.align = "center"}
 knitr::include_graphics("pdf/justification-number.pdf")
 ```
-
 
 ## Column Width 
 
@@ -283,5 +279,3 @@ iris %>%
 ```{r, out.width = "100%", out.height = "400px", echo = FALSE, fig.align = "center"}
 knitr::include_graphics("pdf/color-background.pdf")
 ```
-
-

--- a/vignettes/rtf-text.Rmd
+++ b/vignettes/rtf-text.Rmd
@@ -13,9 +13,7 @@ library(r2rtf)
 library(dplyr)
 ```
 
-
 This vignette documents how to use `rtf_text` and `rtf_paragraph` to customize text and paragraph in details. All output tables are saved in the `vignettes/rtf` folder and assembled in `vignettes/r2rtf_examples.docx` document. 
-
 
 ```{r}
 text <- paste(rep("Sample Text", 20), collapse = " ")
@@ -47,6 +45,7 @@ r2rtf:::write_rtf_para(res, "rtf/para-justification.rtf")
 ```{r, out.width = "100%", out.height = "400px", echo = FALSE, fig.align = "center"}
 knitr::include_graphics("pdf/para-justification.pdf")
 ```
+
 ### Indent 
 
 First line, left, and right indent can be controlled. One can also use a negative number to have the text "outdent".
@@ -85,6 +84,7 @@ r2rtf:::write_rtf_para(res, "rtf/para-line-space.rtf")
 ```{r, out.width = "100%", out.height = "400px", echo = FALSE, fig.align = "center"}
 knitr::include_graphics("pdf/para-line-space.pdf")
 ```
+
 ### Paragraph Space
 
 ```{r}
@@ -112,9 +112,11 @@ r2rtf:::write_rtf_para(res, "rtf/para-page.rtf")
 ```{r, out.width = "100%", out.height = "400px", echo = FALSE, fig.align = "center"}
 knitr::include_graphics("pdf/para-page.pdf")
 ```
+
 ## Text
 
 ### Font Size
+
 ```{r}
 res <- r2rtf:::rtf_paragraph(r2rtf:::rtf_text(text,
   font_size = 8:12
@@ -127,6 +129,7 @@ knitr::include_graphics("pdf/text-font-size-1.pdf")
 ```
 
 ### Text Format
+
 ```{r}
 res <- r2rtf:::rtf_paragraph(r2rtf:::rtf_text(text,
   format = c("b", "i", "bi", "^", "_", "u", "s")
@@ -139,6 +142,7 @@ knitr::include_graphics("pdf/text-format-1.pdf")
 ```
 
 ### Text Font Type
+
 ```{r}
 res <- r2rtf:::rtf_paragraph(r2rtf:::rtf_text(text,
   font = 1:10
@@ -150,8 +154,8 @@ r2rtf:::write_rtf_para(res, "rtf/text-font-type.rtf")
 knitr::include_graphics("pdf/text-font-type.pdf")
 ```
 
-
 ### Text Color
+
 ```{r}
 res <- r2rtf:::rtf_paragraph(r2rtf:::rtf_text(text,
   color = c("red", "gold", "black", "orange", "blue")
@@ -164,6 +168,7 @@ knitr::include_graphics("pdf/text-color.pdf")
 ```
 
 ### Text Background Color
+
 ```{r}
 res <- r2rtf:::rtf_paragraph(r2rtf:::rtf_text(text,
   color = "white",
@@ -179,6 +184,7 @@ knitr::include_graphics("pdf/text-background-color.pdf")
 ### Combine Text in Different Format
 
 This example call `rtf_text` multiple times to combine a text.
+
 ```{r}
 res <- r2rtf:::rtf_paragraph(paste0(
   r2rtf:::rtf_text("3.5"),
@@ -192,7 +198,9 @@ r2rtf:::write_rtf_para(res, "rtf/text-combine1.rtf")
 ```{r, out.width = "100%", out.height = "400px", echo = FALSE, fig.align = "center"}
 knitr::include_graphics("pdf/text-combine1.pdf")
 ```
+
 This example call `rtf_text` one time to combine a text.
+
 ```{r}
 text <- c(3.5, "\\dagger", "\\line red ", "highlight")
 format <- c("", "^", "", "")
@@ -216,6 +224,7 @@ knitr::include_graphics("pdf/text-combine2.pdf")
 ```
 
 ### Inline Formatting
+
 This example provide an inline formatting options with superscript and subscript. It is important to note the location of `{}` is before the special character.
 
 ```{r}


### PR DESCRIPTION
This PR adds an extra level of hierarchy to the vignette headings (e.g. from h1 to h2) when necessary so that the floating TOC can be rendered correctly under > pkgdown 2.0.0.