### PR TITLE
avoid warning if there are multiple footnote or data source in R4.2.0

### DIFF
--- a/R/content_create.R
+++ b/R/content_create.R
@@ -294,7 +294,7 @@ as_rtf_footnote <- function(tbl) {
     text_matrix <- matrix(paste(text_matrix, collapse = "\\line "), nrow = 1, ncol = 1)
 
     attr(text, "text_convert") <- matrix(FALSE, nrow = 1, ncol = 1)
-    attributes(text_matrix) <- append(attributes(text_matrix), attributes(text))
+    attributes(text_matrix) <- append(attributes(text_matrix), lapply(attributes(text), `[`, 1) )
     attr(text_matrix, "col_rel_width") <- 1
     encode <- rtf_table_content(text_matrix,
       col_total_width = attr(tbl, "page")$col_width,
@@ -342,7 +342,7 @@ as_rtf_source <- function(tbl) {
     text_matrix <- matrix(paste(text_matrix, collapse = "\\line "), nrow = 1, ncol = 1)
 
     attr(text, "text_convert") <- matrix(FALSE, nrow = 1, ncol = 1)
-    attributes(text_matrix) <- append(attributes(text_matrix), attributes(text))
+    attributes(text_matrix) <- append(attributes(text_matrix), lapply(attributes(text), `[`, 1) )
     attr(text_matrix, "col_rel_width") <- 1
     encode <- rtf_table_content(text_matrix,
       col_total_width = attr(tbl, "page")$col_width,


### PR DESCRIPTION
To address the warning from R4.2.0

https://cran.r-project.org/doc/manuals/r-release/NEWS.html

> matrix(x, n, m) now warns in more cases where length(x) differs from n * m, as suggested by Abby Spurdle and Wolfgang Huber in Feb 2021 on the R-devel mailing list.

https://github.com/Merck/metalite.ae/issues/4