### PR TITLE
enhance rtf_assemble

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,11 +1,12 @@
 Package: r2rtf
 Title: Easily Create Production-Ready Rich Text Format (RTF) Table and Figure
-Version: 0.3.5.9000
+Version: 0.3.5.9001
 Authors@R: c(
     person("Yilong", "Zhang", email = "elong0527@gmail.com", role = c("aut", "cre")),
     person("Siruo", "Wang", role = "aut"),
     person("Simiao", "Ye", role = "aut"),
     person("Fansen", "Kong", role = "aut"),
+    person("Brian", "Lang", role = "aut"),
     person("Nan", "Xiao", role = "ctb"),
     person("Madhusudhan", "Ginnaram", role = "ctb"),
     person("Ruchitbhai", "Patel", role = "ctb"),
@@ -19,7 +20,6 @@ Authors@R: c(
     person("Jeff", "Cheng", role = "ctb"),
     person("Yirong", "Cao", role = "ctb"),
     person("Amin", "Shirazi", role = "ctb"),
-    person("Brian", "Lang", role = "ctb"),
     person("Merck Sharp & Dohme Corp", role = "cph")
     )
 Description: Create production-ready Rich Text Format (RTF) table and figure

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -48,4 +48,4 @@ Suggests:
     tidyr
 Config/testthat/edition: 3
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2

--- a/R/check_args.R
+++ b/R/check_args.R
@@ -42,7 +42,7 @@
 #' check_args(arg = tbl, type = c("data.frame"))
 #'
 #' vec <- c("a", "b", "c")
-#' check_args(arg = vec, type = c("character"), length = 3)
+#' check_args(arg = vec, type = c("character"), length = c(2,4))
 #' }
 #'
 check_args <- function(arg, type, length = NULL, dim = NULL) {
@@ -61,8 +61,8 @@ check_args <- function(arg, type, length = NULL, dim = NULL) {
   }
 
   if (!is.null(length)) {
-    check[["length"]] <- all(length(arg) == length) & (!is.null(length(arg)))
-    message[["length"]] <- paste("The argument length is not", length)
+    check[["length"]] <- all(length(arg) %in% length) & (!is.null(length(arg)))
+    message[["length"]] <- paste("The argument length is not", paste(length, collapse = ", ") )
   }
 
   if (!is.null(dim)) {

--- a/R/rtf_assemble.R
+++ b/R/rtf_assemble.R
@@ -4,7 +4,8 @@
 #' as RTF file or Microsft Word in `docx` format.
 #'
 #' @param input Character vector of file path.
-#' @param output Character string to the output file path.
+#' @param output Character string to the output file path. File extension should
+#' be `.docx` if `use_officer = TRUE` and `.rtf` if `FALSE`.
 #' @param landscape Logical vector to determine whether to
 #' display files as portrait or landscape. If `use_officer = FALSE`, only singular value is allowed.
 #' @param use_officer Logical value to determine whether the package `officer`
@@ -66,6 +67,8 @@ rtf_assemble <- function(input,
   # assemble RTF
   if (use_officer) {
     message("Assemble rtf files into a '.docx' file using `officer` package.")
+    if (!require(officer, quietly = TRUE)) stop("Use_officer = TRUE, but the ",
+      "officer package is not installed.")
 
     field <- ifelse(grepl("/", input),
                     paste0("INCLUDETEXT \"", gsub("/", "\\\\\\\\", input), "\""),
@@ -104,7 +107,7 @@ rtf_assemble <- function(input,
     end <- vapply(rtf, length, numeric(1))
     end[-n] <- end[-n] - 1
 
-    for (i in 1:n) {
+    for (i in seq_len(n)) {
       rtf[[i]] <- rtf[[i]][start[i]:end[i]]
       if (i < n) rtf[[i]] <- c(rtf[[i]], r2rtf:::as_rtf_new_page())
     }

--- a/R/rtf_assemble.R
+++ b/R/rtf_assemble.R
@@ -1,13 +1,14 @@
-#' Assemble RTF TLFs
+#' Assemble Multiple RTF Table Listing and Figure Into One Document
 #'
-#' Add a set of RTF/TEXT fields into an rdocx object.
+#' The function asseble multiple RTF table, listing, and figures into one document
+#' as RTF file or Microsft Word in `docx` format.
 #'
 #' @param input Character vector of file path.
 #' @param output Character string to the output file path.
 #' @param landscape Logical vector to determine whether to
-#' display files as portrait or landscape.
-#' @param use_officer Logical value to determine whether the package officer::
-#' should be used to assemble rtfs.
+#' display files as portrait or landscape. If `use_officer = FALSE`, only singular value is allowed.
+#' @param use_officer Logical value to determine whether the package `officer`
+#' should be used to assemble RTF table, listing and figure.
 #'
 #' @section Specification:
 #' \if{latex}{
@@ -21,56 +22,55 @@
 #' }
 #'
 #' @examples
-#' \dontrun{
+#' input <- list.files("vignettes/rtf", pattern = "*.rtf", full.names = TRUE)
+#' output <- tempfile(fileext = ".rtf")
+#'
 #' rtf_assemble(
-#'   list.files(
-#'     "outtable/",
-#'     pattern = "*.rtf",
-#'     full.names = TRUE
-#'   ),
-#'   output = "tmp.docx"
+#'   input = input,
+#'   output = output,
+#'   use_officer = FALSE
 #' )
-#' }
 #'
 #' @export
-rtf_assemble <- function(input, output, landscape = FALSE, use_officer = require(officer, quietly = TRUE)) {
-  if (!is.logical(landscape)) stop("Landscape argument must be of type 'logical'.")
-  if (!is.character(input)) stop("Input argument must be of type 'character'.")
-  if (!is.character(output)) stop("Output argument must be of type 'character'.")
-  if (!is.logical(use_officer)) stop("Use_officer argument must be of type 'logical'.")
-  if (!(length(landscape) %in% c(1, length(input)))) {
-    stop(
-      "Landscape argument is length ", length(landscape),
-      " but must be length 1 or ", length(input), " (input length)."
-    )
-  }
+rtf_assemble <- function(input,
+                         output,
+                         landscape = FALSE,
+                         use_officer = TRUE) {
 
+  # input checking
+  check_args(input, type = "character")
+  check_args(output, type = "character", length = 1)
+  check_args(use_officer, type = "logical", length = 1)
 
-  # We need to choose correct extension based on officer:: use.
-  output_ext <- ifelse(use_officer, ".docx", ".rtf")
-
-  # We need to remove extension from output
-  output <- paste0(regmatches(x = output,
-    m = gregexpr(pattern = "^[aA-zZ0-9_]+", text = output))[[1]],
-    output_ext)
-
+  # define variables
   input <- normalizePath(input)
+  n_input <- length(input)
+  missing_input <- input[! file.exists(input)]
+  ext_output <- tolower(tools::file_ext(output))
 
-  if (!all(file.exists(input))) {
-    warning("Some files do not exist and will not be included in the final document.")
+  # input checking based on use_officer
+  if(use_officer){
+    check_args(landscape, "logical", length = c(1, n_input))
+    landscape <- rep(landscape, length.out = n_input)
+    match_arg(ext_output, "docx")
+  }else{
+    check_args(landscape, "logical", length = 1)
+    match_arg(ext_output, "rtf")
   }
 
-  field <- ifelse(grepl("/", input),
-    paste0("INCLUDETEXT \"", gsub("/", "\\\\\\\\", input), "\""),
-    paste0("INCLUDETEXT \"", gsub("\\", "\\\\", input, fixed = "TRUE"), "\"")
-  )
-
-  if (length(landscape) == 1) {
-    landscape <- rep(landscape, length(field))
+  # warning missing input
+  if(length(missing_input) > 0){
+    warning("Missing files: \n", paste(missing_input, collapse = "\n"))
   }
 
+  # assemble RTF
   if (use_officer) {
-    message("Appending rtf files into a '.docx' file with the use of officer:: package.")
+    message("Assemble rtf files into a '.docx' file using `officer` package.")
+
+    field <- ifelse(grepl("/", input),
+                    paste0("INCLUDETEXT \"", gsub("/", "\\\\\\\\", input), "\""),
+                    paste0("INCLUDETEXT \"", gsub("\\", "\\\\", input, fixed = "TRUE"), "\"")
+    )
 
     docx <- officer::read_docx()
 
@@ -95,8 +95,8 @@ rtf_assemble <- function(input, output, landscape = FALSE, use_officer = require
       print(docx, target = output)
     }
   } else {
-    message("Appending rtf files into a '.rtf' without the use of officer:: package,",
-      "page orientation will be ignored.")
+
+    message("Assemble rtf files into a '.rtf' without using `officer` package.")
 
     rtf <- lapply(input, readLines)
     n <- length(rtf)

--- a/man/check_args.Rd
+++ b/man/check_args.Rd
@@ -42,7 +42,7 @@ tbl < -as.data.frame(matrix(1:9, nrow = 3))
 check_args(arg = tbl, type = c("data.frame"))
 
 vec <- c("a", "b", "c")
-check_args(arg = vec, type = c("character"), length = 3)
+check_args(arg = vec, type = c("character"), length = c(2,4))
 }
 
 }

--- a/man/rtf_assemble.Rd
+++ b/man/rtf_assemble.Rd
@@ -9,7 +9,8 @@ rtf_assemble(input, output, landscape = FALSE, use_officer = TRUE)
 \arguments{
 \item{input}{Character vector of file path.}
 
-\item{output}{Character string to the output file path.}
+\item{output}{Character string to the output file path. File extension should
+be \code{.docx} if \code{use_officer = TRUE} and \code{.rtf} if \code{FALSE}.}
 
 \item{landscape}{Logical vector to determine whether to
 display files as portrait or landscape. If \code{use_officer = FALSE}, only singular value is allowed.}

--- a/man/rtf_assemble.Rd
+++ b/man/rtf_assemble.Rd
@@ -2,14 +2,9 @@
 % Please edit documentation in R/rtf_assemble.R
 \name{rtf_assemble}
 \alias{rtf_assemble}
-\title{Assemble RTF TLFs}
+\title{Assemble Multiple RTF Table Listing and Figure Into One Document}
 \usage{
-rtf_assemble(
-  input,
-  output,
-  landscape = FALSE,
-  use_officer = require(officer, quietly = TRUE)
-)
+rtf_assemble(input, output, landscape = FALSE, use_officer = TRUE)
 }
 \arguments{
 \item{input}{Character vector of file path.}
@@ -17,13 +12,14 @@ rtf_assemble(
 \item{output}{Character string to the output file path.}
 
 \item{landscape}{Logical vector to determine whether to
-display files as portrait or landscape.}
+display files as portrait or landscape. If \code{use_officer = FALSE}, only singular value is allowed.}
 
-\item{use_officer}{Logical value to determine whether the package officer::
-should be used to assemble rtfs.}
+\item{use_officer}{Logical value to determine whether the package \code{officer}
+should be used to assemble RTF table, listing and figure.}
 }
 \description{
-Add a set of RTF/TEXT fields into an rdocx object.
+The function asseble multiple RTF table, listing, and figures into one document
+as RTF file or Microsft Word in \code{docx} format.
 }
 \section{Specification}{
 
@@ -39,15 +35,13 @@ The contents of this section are shown in PDF user manual only.
 }
 
 \examples{
-\dontrun{
+input <- list.files("vignettes/rtf", pattern = "*.rtf", full.names = TRUE)
+output <- tempfile(fileext = ".rtf")
+
 rtf_assemble(
-  list.files(
-    "outtable/",
-    pattern = "*.rtf",
-    full.names = TRUE
-  ),
-  output = "tmp.docx"
+  input = input,
+  output = output,
+  use_officer = FALSE
 )
-}
 
 }

--- a/tests/testthat/test-independent-testing-rtf_assemble.R
+++ b/tests/testthat/test-independent-testing-rtf_assemble.R
@@ -1,6 +1,7 @@
 # test bulletproofing
 
 test_that("rtf_assemble: bulletproofing argument landscape", {
+
   withr::with_tempdir({
     a <- "Just a random Text and Symbols.!@#$%^&*()[],:; \ <>"
     write_rtf(a, file = "table1.rtf")
@@ -8,22 +9,24 @@ test_that("rtf_assemble: bulletproofing argument landscape", {
     write_rtf(b, file = "table2.rtf")
 
     expect_error(rtf_assemble(input = dir(pattern = "table"),
-      output = "tmp",
-      landscape = "yes"),
-      regexp = "Landscape argument must be of type 'logical'.")
+                              output = "tmp.rtf",
+                              landscape = "yes",
+                              use_officer = FALSE))
+
     expect_error(rtf_assemble(input = dir(pattern = "table"),
-      output = "tmp",
-      landscape = c(TRUE, TRUE, FALSE)),
-      regexp = "Landscape argument is length")
+                              output = "tmp.docx",
+                              landscape = c(TRUE, TRUE, FALSE),
+                              use_officer = TRUE))
 
   })
 })
 
 test_that("rtf_assemble: bulletproofing argument input", {
+
   withr::with_tempdir({
-    expect_error(rtf_assemble(input = c(TRUE, TRUE), output = "tmp"),
-      regexp = "Input argument must be of type 'character'.")
+    expect_error(rtf_assemble(input = c(TRUE, TRUE), output = "tmp"))
   })
+
 })
 
 test_that("rtf_assemble: bulletproofing argument output", {
@@ -33,8 +36,7 @@ test_that("rtf_assemble: bulletproofing argument output", {
     b <- "Just a random Text and Symbols.!@#$%^&*()[],:; \ <>"
     write_rtf(b, file = "table2.rtf")
 
-    expect_error(rtf_assemble(input = dir(pattern = "table"), output = TRUE),
-      regexp = "Output argument must be of type 'character'.")
+    expect_error(rtf_assemble(input = dir(pattern = "table"), output = TRUE))
   })
 })
 
@@ -46,8 +48,7 @@ test_that("rtf_assemble: bulletproofing argument use_officer", {
     write_rtf(b, file = "table2.rtf")
 
     expect_error(rtf_assemble(input = dir(pattern = "table"), output = "tmp",
-      use_officer = "yes"),
-      regexp = "Use_officer argument must be of type 'logical'.")
+                 use_officer = "yes"))
   })
 })
 
@@ -60,10 +61,10 @@ test_that("rtf_assemble: output without using officer", {
     write_rtf(b, file = "table2.rtf")
 
     expect_message(rtf_path <- rtf_assemble(input = dir(pattern = "table"),
-      output = "tmp_rtf",
-      use_officer = FALSE), regexp = "page orientation will be ignored.")
+      output = "tmp.rtf",
+      use_officer = FALSE), regexp = "without using `officer` package.")
 
-    expect_equal(rtf_path, "tmp_rtf.rtf")
+    expect_equal(rtf_path, "tmp.rtf")
     expect_true(rtf_path %in% dir())
 
     tmp_rtf <- paste(readLines(rtf_path), collapse = "\n")
@@ -85,15 +86,15 @@ if (require(officer, quietly = TRUE)){
       write_rtf(b, file = "table2.rtf")
 
       expect_message(rtf_path <- rtf_assemble(input = dir(pattern = "table"),
-        output = "tmp_docx",
-        use_officer = TRUE),
-        regexp = "Appending rtf files into a '.docx'")
+                                              output = "tmp.docx",
+                                              use_officer = TRUE),
+        regexp = "'.docx' file using `officer` package.")
 
-      expect_equal(rtf_path, "tmp_docx.docx")
+      expect_equal(rtf_path, "tmp.docx")
       expect_true(rtf_path %in% dir())
 
       # Need to read in and expose document text for our test
-      tmp_docx <- docx_summary(officer::read_docx(rtf_path))
+      tmp_docx <- officer::docx_summary(officer::read_docx(rtf_path))
 
       # Need to check if both "table seq table" texts are in the docx file.
       expect_equal(grepl("Table SEQ Table", tmp_docx$text),


### PR DESCRIPTION
- using `check_args` for input checking.
- update `check_args` to allow a vector of length.
- update default value of `use_officer`
- update test file to pass checks.