### PR TITLE
#141 display proper indentation for footnote and data source

### DIFF
--- a/man/as_rtf_footnote.Rd
+++ b/man/as_rtf_footnote.Rd
@@ -4,10 +4,12 @@
 \alias{as_rtf_footnote}
 \title{Create Footnote RTF Encode}
 \usage{
-as_rtf_footnote(tbl)
+as_rtf_footnote(tbl, attr_name = "rtf_footnote")
 }
 \arguments{
 \item{tbl}{A data frame.}
+
+\item{attr_name}{a character value of attribute name.}
 }
 \description{
 Create Footnote RTF Encode

--- a/man/assemble_docx.Rd
+++ b/man/assemble_docx.Rd
@@ -36,9 +36,15 @@ library(officer)
 library(magrittr)
 
 file <- replicate(2, tempfile(fileext = ".rtf"))
-file1 <- head(iris) \%>\% rtf_body() \%>\% rtf_encode() \%>\% write_rtf(file[1])
-file2 <- head(cars) \%>\% rtf_page(orientation = "landscape") \%>\%
-              rtf_body() \%>\% rtf_encode() \%>\% write_rtf(file[2])
+file1 <- head(iris) \%>\%
+  rtf_body() \%>\%
+  rtf_encode() \%>\%
+  write_rtf(file[1])
+file2 <- head(cars) \%>\%
+  rtf_page(orientation = "landscape") \%>\%
+  rtf_body() \%>\%
+  rtf_encode() \%>\%
+  write_rtf(file[2])
 output <- tempfile(fileext = ".docx")
 
 assemble_docx(

--- a/man/assemble_rtf.Rd
+++ b/man/assemble_rtf.Rd
@@ -35,9 +35,15 @@ The contents of this section are shown in PDF user manual only.
 library(magrittr)
 
 file <- replicate(2, tempfile(fileext = ".rtf"))
-file1 <- head(iris) \%>\% rtf_body() \%>\% rtf_encode() \%>\% write_rtf(file[1])
-file2 <- head(cars) \%>\% rtf_page(orientation = "landscape") \%>\%
-              rtf_body() \%>\% rtf_encode() \%>\% write_rtf(file[2])
+file1 <- head(iris) \%>\%
+  rtf_body() \%>\%
+  rtf_encode() \%>\%
+  write_rtf(file[1])
+file2 <- head(cars) \%>\%
+  rtf_page(orientation = "landscape") \%>\%
+  rtf_body() \%>\%
+  rtf_encode() \%>\%
+  write_rtf(file[2])
 output <- tempfile(fileext = ".rtf")
 
 assemble_rtf(

--- a/man/check_args.Rd
+++ b/man/check_args.Rd
@@ -42,7 +42,7 @@ tbl < -as.data.frame(matrix(1:9, nrow = 3))
 check_args(arg = tbl, type = c("data.frame"))
 
 vec <- c("a", "b", "c")
-check_args(arg = vec, type = c("character"), length = c(2,4))
+check_args(arg = vec, type = c("character"), length = c(2, 4))
 }
 
 }

--- a/man/rtf_read_figure.Rd
+++ b/man/rtf_read_figure.Rd
@@ -29,7 +29,7 @@ Supported format is listed in \code{r2rtf:::fig_format()}.
 \dontrun{
 
 # Read in PNG file in binary format
-file <- tempfile("figure",fileext=".png")
+file <- tempfile("figure", fileext = ".png")
 png(file)
 plot(1:10)
 dev.off()
@@ -37,16 +37,13 @@ dev.off()
 
 rtf_read_figure(file)
 
-\dontrun{
 # Read in EMF file in binary format
 library(devEMF)
-file <- tempfile("figure",fileext=".emf")
+file <- tempfile("figure", fileext = ".emf")
 emf(file)
 plot(1:10)
 dev.off()
 
 rtf_read_figure(file)
-}
-
 }
 }


### PR DESCRIPTION
Address bug in #141 

example:

```
footnote <- c(
  paste(rep("a", 200), collapse = ""), 
  paste(rep("b", 200), collapse = "")
)

iris %>% 
  head() %>%
  rtf_body() %>% 
  rtf_footnote(footnote, 
               text_indent_first = -200, 
               text_indent_left = 200) %>% 
  rtf_encode() %>% 
  write_rtf("tmp.rtf")
```