### PR TITLE
Add Linguist rule

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.rtf linguist-generated
+*.html linguist-generated


### PR DESCRIPTION
This PR adds rules to `.gitattributes` to mark all `.rtf` and `.html` files as "generated" for GitHub Linguist so the repo languages statistics is correct (currently, RTF and HTML rank at the top by number of lines).

GitHub Linguist references: [[1](https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github)] and [[2](https://github.com/github/linguist/blob/master/docs/overrides.md)].