### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,36 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**To reproduce**
+Please include a minimal reproducible example.
+Consider using [reprex](http://reprex.tidyverse.org/).
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Session info**
+If the bug is related to specific package versions or version combinations,
+paste the session info into the code block below.
+
+<details> <summary><strong>Session Info</strong></summary>
+
+```
+# Insert `sessionInfo()` or `devtools::session_info()` output here
+```
+
+</details>
+
+**Additional context**
+Add any other useful context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,48 @@
+---
+name: Question
+about: Ask a question or request clarification
+title: ''
+labels: question
+assignees: ''
+
+---
+
+**Question**
+Please provide a clear and concise description of your question.
+
+**Context**
+Provide any background information or context that can help us better
+understand your question. If your question is related to a specific part
+of the code or documentation, please include links or references.
+
+**What have you tried so far?**
+Describe any research or attempts you have made to find the answer to
+your question. This will help us avoid providing redundant information
+and better understand where you need help.
+
+**To reproduce**
+If this issue is related to usage of the package,
+please include a minimal reproducible example.
+Consider using [reprex](http://reprex.tidyverse.org/).
+
+```r
+# Insert reprex here
+```
+
+**Screenshots**
+If applicable, add screenshots to help explain your question.
+
+**Session info**
+If the question is related to specific package versions or version combinations,
+paste the session info into the code block below.
+
+<details> <summary><strong>Session Info</strong></summary>
+
+```
+# Insert `sessionInfo()` or `devtools::session_info()` output here
+```
+
+</details>
+
+**Additional context**
+Add any other useful context about the question here.


### PR DESCRIPTION
This PR adds three [GitHub issue templates](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository), slightly modified from the default templates:

- Report bug
- Feature request
- Question

Users will be instructed to select an issue type from them when creating a new issue.

This could potentially help address expectation misalignments such as not including a minimal reproducible example or sufficient context when submitting bug reports or asking questions.