### PR TITLE
Add citation details

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -44,3 +44,4 @@ lib_paths
 ^r2rtf\.Rcheck$
 ^r2rtf.*\.tar\.gz$
 ^r2rtf.*\.tgz$
+^CITATION\.cff$

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -28,7 +28,5 @@ preferred-citation:
     given-names: "Yilong"
   title: "r2rtf---an R Package to Produce Rich Text Format (RTF) Tables and Figures"
   year: 2020
-  conference:
-    - name: PharmaSUG
-    location: San Francisco, California
+  collection-title: "PharmaSUG"
   url: "https://www.pharmasug.org/proceedings/2020/DV/PharmaSUG-2020-DV-198.pdf"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,34 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+authors:
+- family-names: "Zhang"
+  given-names: "Yilong"
+- family-names: "Wang"
+  given-names: "Siruo"
+- family-names: "Ye"
+  given-names: "Simiao"
+- family-names: "Kong"
+  given-names: "Fansen"
+- family-names: "Lang"
+  given-names: "Brian"
+title: "r2rtf: Easily Create Production-Ready Rich Text Format (RTF) Table and Figure"
+version: 1.0.1
+date-released: 2020-02-19
+url: "https://github.com/Merck/r2rtf"
+preferred-citation:
+  type: conference-paper
+  authors:
+  - family-names: "Wang"
+    given-names: "Siruo"
+  - family-names: "Ye"
+    given-names: "Simiao"
+  - family-names: "Anderson"
+    given-names: "Keaven"
+  - family-names: "Zhang"
+    given-names: "Yilong"
+  title: "r2rtf---an R Package to Produce Rich Text Format (RTF) Tables and Figures"
+  year: 2020
+  conference:
+    - name: PharmaSUG
+    location: San Francisco, California
+  url: "https://www.pharmasug.org/proceedings/2020/DV/PharmaSUG-2020-DV-198.pdf"

--- a/README.Rmd
+++ b/README.Rmd
@@ -1,6 +1,8 @@
 ---
-output: md_document
+output: github_document
 ---
+
+<!-- README.md is generated from README.Rmd. Please edit that file -->
 
 # r2rtf <img src="man/figures/logo.png" align="right" width="120" />
 
@@ -22,18 +24,18 @@ pkgname <- "r2rtf"
 
 ## Overview
 
-`r2rtf` is an R package to create production-ready tables and figures in RTF format.
-The R package is designed to 
+r2rtf is an R package to create production-ready tables and figures in RTF format.
+The package is designed with these principles:
 
-- provide simple "verb" functions that correspond to each component of a table, 
+- Provide simple "verb" functions that correspond to each component of a table,
   to help you translate data frame(s) to a table in RTF file.
-- enables pipes (`%>%`). 
-- only focus on **table format**. 
-  + Data manipulation and analysis shall be handled by other R packages. (e.g., `tidyverse`)
-- minimizes package dependency 
+- Functions are chainable with pipes (`%>%`).
+- Only focus on **table format**.
+  - Data manipulation and analysis should be handled by other R packages, for example, tidyverse.
+- Minimize package dependency.
 
-The [R for clinical study reports and submission](https://r4csr.org/) book 
-provides tutorials by using real world examples.   
+The [R for clinical study reports and submission](https://r4csr.org/) book
+provides tutorials by using real world examples.
 
 ## Installation
 
@@ -49,28 +51,28 @@ Or, install from GitHub:
 remotes::install_github("Merck/r2rtf")
 ```
 
-## Highlighted Features 
+## Highlighted features
 
-The R package`r2rtf` provided flexibility to enable features below:
+The R package r2rtf provides flexibility to enable features below:
 
-* Create highly customized RTF table and figure ready for production. 
-* Simple to use parameters and data structure.
-    + Customized column header: split by `"|"`. 
-    + Three required parameters for the output tables (data, filename, column relative width).
-    + Flexible and detail control of table structure. 
-* Format control in cell, row, column and table level for: 
-    + Border Type: single, double, dash, dot, etc.
-    + Alignment: left, right, center, decimal.
-    + Column width. 
-    + Text appearance: **bold**, *italics*, ~~strikethrough~~, underline and any combinations.
-    + Font size. 
-    + Text and border color (`r length(colors())` different colors named in `color()` function).
-    + Special characters: any character in UTF-8 encoding (e.g., Greek, Symbol, Chinese, Japanese, Korean).
-* Append several tables into one file. 
-* Pagination.
-* Built-in raw data for validation.
+- Create highly customized RTF table and figure ready for production.
+- Simple to use parameters and data structure.
+  - Customized column header: split by `"|"`.
+  - Three required parameters for the output tables (data, filename, column relative width).
+  - Flexible and detail control of table structure.
+- Format control in cell, row, column and table level for:
+  - Border Type: single, double, dash, dot, etc.
+  - Alignment: left, right, center, decimal.
+  - Column width.
+  - Text appearance: **bold**, *italics*, ~~strikethrough~~, underline and any combinations.
+  - Font size.
+  - Text and border color (`r length(colors())` different colors named in `color()` function).
+  - Special characters: any character in UTF-8 encoding (e.g., Greek, Symbol, Chinese, Japanese, Korean).
+- Append several tables into one file.
+- Pagination.
+- Built-in raw data for validation.
 
-## Simple Example 
+## Simple example
 
 ```{r, eval = FALSE}
 library(dplyr)
@@ -103,7 +105,7 @@ try(
 
 - [More Examples](https://merck.github.io/r2rtf/articles/index.html)
 
-## Example Efficacy Table
+## Example efficacy table
 
 - [Source code](https://merck.github.io/r2rtf/articles/example-efficacy.html)
 
@@ -111,7 +113,7 @@ try(
 <img src="https://merck.github.io/r2rtf/articles/fig/efficacy_example.png">
 </details>
 
-## Example Safety Table
+## Example safety table
 
 - [Source code](https://merck.github.io/r2rtf/articles/example-ae-summary.html)
 
@@ -135,14 +137,11 @@ r2rtf:::rtf_convert_format(
   output_dir = "vignettes/docx"
 )
 
-
-
 r2rtf:::rtf_convert_format(
   input = files,
   format = "html",
   output_dir = "vignettes/html"
 )
-
 
 files <- list.files("vignettes/rtf", pattern = "*\\.rtf")
 files_pdf <- list.files("vignettes/pdf", pattern = "*\\.pdf")
@@ -164,4 +163,24 @@ waldo::compare(
   tools::file_path_sans_ext(files),
   tools::file_path_sans_ext(files_html)
 )
+```
+
+## Citation
+
+If you use this software, please cite it as below.
+
+> Wang, S., Ye, S., Anderson, K., & Zhang, Y. (2020).
+> r2rtf---an R Package to Produce Rich Text Format (RTF) Tables and Figures.
+> _PharmaSUG_. https://www.pharmasug.org/proceedings/2020/DV/PharmaSUG-2020-DV-198.pdf
+
+A BibTeX entry for LaTeX users is
+
+```bibtex
+@inproceedings{wang2020r2rtf,
+  title     = {{r2rtf}---an {R} Package to Produce {Rich Text Format} ({RTF}) Tables and Figures},
+  author    = {Wang, Siruo and Ye, Simiao and Anderson, Keaven M and Zhang, Yilong},
+  booktitle = {PharmaSUG},
+  year      = {2020},
+  url       = {https://www.pharmasug.org/proceedings/2020/DV/PharmaSUG-2020-DV-198.pdf}
+}
 ```

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+
+<!-- README.md is generated from README.Rmd. Please edit that file -->
+
 # r2rtf <img src="man/figures/logo.png" align="right" width="120" />
 
 <!-- badges: start -->
@@ -14,61 +17,70 @@ Downloads](https://cranlogs.r-pkg.org/badges/r2rtf)](https://cran.r-project.org/
 
 ## Overview
 
-`r2rtf` is an R package to create production-ready tables and figures in
-RTF format. The R package is designed to
+r2rtf is an R package to create production-ready tables and figures in
+RTF format. The package is designed with these principles:
 
--   provide simple “verb” functions that correspond to each component of
-    a table, to help you translate data frame(s) to a table in RTF file.
--   enables pipes (`%>%`).
--   only focus on **table format**.
-    -   Data manipulation and analysis shall be handled by other R
-        packages. (e.g., `tidyverse`)
--   minimizes package dependency
+- Provide simple “verb” functions that correspond to each component of a
+  table, to help you translate data frame(s) to a table in RTF file.
+- Functions are chainable with pipes (`%>%`).
+- Only focus on **table format**.
+  - Data manipulation and analysis should be handled by other R
+    packages, for example, tidyverse.
+- Minimize package dependency.
+
+The [R for clinical study reports and submission](https://r4csr.org/)
+book provides tutorials by using real world examples.
 
 ## Installation
 
 You can install the package via CRAN:
 
-    install.packages("r2rtf")
+``` r
+install.packages("r2rtf")
+```
 
 Or, install from GitHub:
 
-    remotes::install_github("Merck/r2rtf")
+``` r
+remotes::install_github("Merck/r2rtf")
+```
 
-## Highlighted Features
+## Highlighted features
 
-The R package`r2rtf` provided flexibility to enable features below:
+The R package r2rtf provides flexibility to enable features below:
 
--   Necessary options to create highly customized RTF table and figure.
--   Simple to use parameters and data structure.
-    -   Customized column header: split by `"|"`.
-    -   Three required parameters for the output tables (data, filename,
-        column relative width).
-    -   Flexible and detail control of table structure.
--   Format control in cell, row, column and table level for:
-    -   Border Type: single, double, dash, dot, etc.
-    -   Alignment: left, right, center, decimal.
-    -   Column width.
-    -   Text appearance: **bold**, *italics*, <s>strikethrough</s>,
-        underline and any combinations.
-    -   Font size.
-    -   Text and border color (657 different colors named in `color()`
-        function).
-    -   Special characters: any character in UTF-8 encoding (e.g.,
-        Greek, Symbol, Chinese, Japanese, Korean).
--   Append several tables into one file.
--   Pagination.
--   Built-in raw data for validation.
+- Create highly customized RTF table and figure ready for production.
+- Simple to use parameters and data structure.
+  - Customized column header: split by `"|"`.
+  - Three required parameters for the output tables (data, filename,
+    column relative width).
+  - Flexible and detail control of table structure.
+- Format control in cell, row, column and table level for:
+  - Border Type: single, double, dash, dot, etc.
+  - Alignment: left, right, center, decimal.
+  - Column width.
+  - Text appearance: **bold**, *italics*, ~~strikethrough~~, underline
+    and any combinations.
+  - Font size.
+  - Text and border color (657 different colors named in `color()`
+    function).
+  - Special characters: any character in UTF-8 encoding (e.g., Greek,
+    Symbol, Chinese, Japanese, Korean).
+- Append several tables into one file.
+- Pagination.
+- Built-in raw data for validation.
 
-## Simple Example
+## Simple example
 
-    library(dplyr)
-    library(r2rtf)
+``` r
+library(dplyr)
+library(r2rtf)
 
-    head(iris) %>%
-      rtf_body() %>%                 # Step 1 Add attributes
-      rtf_encode() %>%               # Step 2 Convert attributes to RTF encode
-      write_rtf(file = "ex-tbl.rtf") # Step 3 Write to a .rtf file
+head(iris) %>%
+  rtf_body() %>% # Step 1 Add attributes
+  rtf_encode() %>% # Step 2 Convert attributes to RTF encode
+  write_rtf(file = "ex-tbl.rtf") # Step 3 Write to a .rtf file
+```
 
 <details>
 <summary>
@@ -77,12 +89,12 @@ Click here to see the output
 <img src="https://merck.github.io/r2rtf/articles/fig/ex-tbl.png">
 </details>
 
--   [More Examples](https://merck.github.io/r2rtf/articles/index.html)
+- [More Examples](https://merck.github.io/r2rtf/articles/index.html)
 
-## Example Efficacy Table
+## Example efficacy table
 
--   [Source
-    code](https://merck.github.io/r2rtf/articles/example-efficacy.html)
+- [Source
+  code](https://merck.github.io/r2rtf/articles/example-efficacy.html)
 
 <details>
 <summary>
@@ -91,10 +103,10 @@ Click here to see the output
 <img src="https://merck.github.io/r2rtf/articles/fig/efficacy_example.png">
 </details>
 
-## Example Safety Table
+## Example safety table
 
--   [Source
-    code](https://merck.github.io/r2rtf/articles/example-ae-summary.html)
+- [Source
+  code](https://merck.github.io/r2rtf/articles/example-ae-summary.html)
 
 <details>
 <summary>
@@ -102,3 +114,23 @@ Click here to see the output
 </summary>
 <img src="https://merck.github.io/r2rtf/articles/fig/ae_example.png">
 </details>
+
+## Citation
+
+If you use this software, please cite it as below.
+
+> Wang, S., Ye, S., Anderson, K., & Zhang, Y. (2020). r2rtf—an R Package
+> to Produce Rich Text Format (RTF) Tables and Figures. *PharmaSUG*.
+> <https://www.pharmasug.org/proceedings/2020/DV/PharmaSUG-2020-DV-198.pdf>
+
+A BibTeX entry for LaTeX users is
+
+``` bibtex
+@inproceedings{wang2020r2rtf,
+  title     = {{r2rtf}---an {R} Package to Produce {Rich Text Format} ({RTF}) Tables and Figures},
+  author    = {Wang, Siruo and Ye, Simiao and Anderson, Keaven M and Zhang, Yilong},
+  booktitle = {PharmaSUG},
+  year      = {2020},
+  url       = {https://www.pharmasug.org/proceedings/2020/DV/PharmaSUG-2020-DV-198.pdf}
+}
+```

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -1,0 +1,8 @@
+bibentry(
+  "InProceedings",
+  title = "{r2rtf}---an {R} Package to Produce {Rich Text Format} ({RTF}) Tables and Figures",
+  author = "Siruo Wang and Simiao Ye and Keaven M Anderson and Yilong Zhang",
+  booktitle = "PharmaSUG",
+  year = "2020",
+  url = "https://www.pharmasug.org/proceedings/2020/DV/PharmaSUG-2020-DV-198.pdf",
+)


### PR DESCRIPTION
This PR adds the citation details for the package using the 2020 PharmaSUG paper.

- `inst/CITATION` so that `citation("r2rtf")` works.
- `CITATION.cff` so that the GitHub repo has a [cite this repository](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-citation-files) button on the right sidebar.
- Plaintext and BibTeX citation section in `README.Rmd` and rendered to `README.md`.