### PR TITLE
Update GitHub Actions workflows to upstream latest versions

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -29,7 +29,7 @@ jobs:
       R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -22,7 +22,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-pandoc@v2
 
@@ -41,7 +41,7 @@ jobs:
 
       - name: Deploy to GitHub pages 🚀
         if: github.event_name != 'pull_request'
-        uses: JamesIves/github-pages-deploy-action@v4.4.1
+        uses: JamesIves/github-pages-deploy-action@v4.5.0
         with:
           clean: false
           branch: gh-pages

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -13,7 +13,7 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -46,7 +46,7 @@ jobs:
         shell: Rscript {0}
 
       - name: Cache styler
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.styler-location.outputs.location }}
           key: ${{ runner.os }}-styler-${{ github.sha }}

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -15,7 +15,7 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-r@v2
         with:
@@ -31,7 +31,7 @@ jobs:
           covr::codecov(
             quiet = FALSE,
             clean = FALSE,
-            install_path = file.path(Sys.getenv("RUNNER_TEMP"), "package")
+            install_path = file.path(normalizePath(Sys.getenv("RUNNER_TEMP"), winslash = "/"), "package")
           )
         shell: Rscript {0}
 
@@ -44,7 +44,7 @@ jobs:
 
       - name: Upload test results
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-test-failures
           path: ${{ runner.temp }}/package

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,6 +1,4 @@
 library(testthat)
-library(dplyr)
 library(r2rtf)
-library(ggplot2)
 
 test_check("r2rtf")

--- a/tests/testthat/test-independent-testing-as_rtf_pageby.R
+++ b/tests/testthat/test-independent-testing-as_rtf_pageby.R
@@ -1,5 +1,3 @@
-library(dplyr)
-
 test_that("Test for case when output has title, footnote and source", {
   x <- iris[1:2, ] |>
     rtf_title("Title") |>
@@ -21,13 +19,13 @@ test_that("Test the pageby rows are the last rows of a page", {
     rtf_pageby(page_by = "Species", new_page = TRUE, pageby_header = FALSE)
 
   y <- as.data.frame(attributes(as_rtf_pageby(x))) |>
-    group_by(info.id) |>
-    summarise_all(last) |>
-    mutate(row = substr(as.character(info.page), 1, 1))
+    dplyr::group_by(info.id) |>
+    dplyr::summarise_all(dplyr::last) |>
+    dplyr::mutate(row = substr(as.character(info.page), 1, 1))
 
   z <- as.data.frame(table(x$Species)) |>
-    mutate(cu = cumsum(Freq))
-  z <- z |> mutate(cum = cu + as.numeric(rownames(z)))
+    dplyr::mutate(cu = cumsum(Freq))
+  z <- z |> dplyr::mutate(cum = cu + as.numeric(rownames(z)))
 
   expect_equal(y$row, rownames(y))
   expect_equal(y$info.index, z$cum)
@@ -66,8 +64,8 @@ test_that("Test if page_dict attribute is created for tbl", {
 
 test_that("Test for more than one page_by var", {
   x <- iris |>
-    mutate(cat = rep(1:5, 30)) |>
-    arrange(Species, cat) |>
+    dplyr::mutate(cat = rep(1:5, 30)) |>
+    dplyr::arrange(Species, cat) |>
     rtf_page(nrow = 5) |>
     rtf_body() |>
     rtf_pageby(page_by = c("Species", "cat"), new_page = TRUE, pageby_header = TRUE)
@@ -92,8 +90,8 @@ test_that("Test if new_page is FALSE and group_by is NOT NULL", {
 })
 
 test_that("Test whether lines with '-----' were removed correctly", {
-  x <- distinct(iris |> subset(Species != "virginica"), Species, .keep_all = T) |>
-    mutate(Species = ifelse(Species == "setosa", "-----", Species)) |>
+  x <- dplyr::distinct(iris |> subset(Species != "virginica"), Species, .keep_all = TRUE) |>
+    dplyr::mutate(Species = ifelse(Species == "setosa", "-----", Species)) |>
     rtf_colheader("Sepal.Length | Sepal.Width | Petal.Length | Petal.Width",
       col_rel_width = rep(1, 4)
     ) |>
@@ -111,8 +109,8 @@ test_that("Test whether lines with '-----' were removed correctly", {
 
 test_that("Test when using subline_by and page_by together in rtf_body", {
   tbl1 <- iris[c(1:4, 51:54), 3:5] |>
-    mutate(s2 = paste0(Species, 1:2), s3 = s2) |>
-    arrange(Species, s2) |>
+    dplyr::mutate(s2 = paste0(Species, 1:2), s3 = s2) |>
+    dplyr::arrange(Species, s2) |>
     rtf_body(
       subline_by = "s2",
       page_by = "Species"
@@ -125,8 +123,8 @@ test_that("Test when using subline_by and page_by together in rtf_body", {
 
 test_that("Test when using subline_by and page_by with pageby_row = 'first_row' in rtf_body", {
   tbl2 <- iris[c(1:4, 51:54), 3:5] |>
-    mutate(s2 = paste0(Species, 1:2), s3 = s2) |>
-    arrange(Species, s2) |>
+    dplyr::mutate(s2 = paste0(Species, 1:2), s3 = s2) |>
+    dplyr::arrange(Species, s2) |>
     rtf_body(
       subline_by = "s2",
       page_by = "Species",

--- a/tests/testthat/test-independent-testing-as_rtf_pageby.R
+++ b/tests/testthat/test-independent-testing-as_rtf_pageby.R
@@ -1,5 +1,5 @@
 library(dplyr)
-svg(tempfile("tmp.svg"))
+
 test_that("Test for case when output has title, footnote and source", {
   x <- iris[1:2, ] |>
     rtf_title("Title") |>
@@ -136,5 +136,3 @@ test_that("Test when using subline_by and page_by with pageby_row = 'first_row' 
 
   expect_snapshot_output(tbl2$body)
 })
-
-dev.off()

--- a/tests/testthat/test-independent-testing-as_rtf_table.R
+++ b/tests/testthat/test-independent-testing-as_rtf_table.R
@@ -31,8 +31,8 @@ test_that("Case for having group_by without page_by", {
 # add additional test to increase coverage and for new feature
 test_that("Test case when subline is not NULL", {
   x <- iris[c(1:4, 51:54), 3:5] |>
-    mutate(s2 = paste0(Species, 1:2), s3 = s2) |>
-    arrange(Species, s2) |>
+    dplyr::mutate(s2 = paste0(Species, 1:2), s3 = s2) |>
+    dplyr::arrange(Species, s2) |>
     rtf_body(
       subline_by = "Species",
       page_by = "s2",
@@ -45,18 +45,18 @@ test_that("Test case when subline is not NULL", {
 
   data(r2rtf_adae)
   ae <- r2rtf_adae[200:260, ] |>
-    arrange(SITEID, TRTA, USUBJID, ASTDY)
+    dplyr::arrange(SITEID, TRTA, USUBJID, ASTDY)
 
   ae <- ae |>
-    mutate(
+    dplyr::mutate(
       AEDECODNUM = as.character(rownames(ae)),
       SUBLINEBY = paste0(
         "Trial Number: ", STUDYID,
         ", Site Number: ", SITEID
       ),
     ) |>
-    select(USUBJID, ASTDY, AEDECODNUM, TRTA, SUBLINEBY) |>
-    arrange(SUBLINEBY, TRTA, USUBJID, ASTDY) |>
+    dplyr::select(USUBJID, ASTDY, AEDECODNUM, TRTA, SUBLINEBY) |>
+    dplyr::arrange(SUBLINEBY, TRTA, USUBJID, ASTDY) |>
     rtf_colheader("Subject| Rel Day | Adverse Code|") |>
     rtf_body(
       subline_by = "SUBLINEBY",

--- a/tests/testthat/test-independent-testing-assemble.R
+++ b/tests/testthat/test-independent-testing-assemble.R
@@ -46,28 +46,28 @@ test_that("rtf_assemble: output without using officer", {
 })
 
 # test functionality with officer
-if (requireNamespace("officer")) {
-  test_that("rtf_assemble: output with using officer", {
-    file_tmp <- tempfile(fileext = ".docx")
-    rtf_path <- assemble_docx(
-      input = file,
-      output = file_tmp,
-      landscape = c(FALSE, TRUE)
-    )
+test_that("rtf_assemble: output with using officer", {
+  skip_if_not_installed("officer")
 
-    expect_equal(rtf_path, file_tmp)
+  file_tmp <- tempfile(fileext = ".docx")
+  rtf_path <- assemble_docx(
+    input = file,
+    output = file_tmp,
+    landscape = c(FALSE, TRUE)
+  )
 
-    # Need to read in and expose document text for our test
-    docx <- officer::read_docx(rtf_path)
-    tmp_docx <- officer::docx_summary(docx)
-    body_docx <- officer::docx_body_xml(docx)
+  expect_equal(rtf_path, file_tmp)
 
-    # Need to check if both "table seq table" texts are in the docx file.
-    expect_true(grepl("Table SEQ Table", tmp_docx$text[1]))
+  # Need to read in and expose document text for our test
+  docx <- officer::read_docx(rtf_path)
+  tmp_docx <- officer::docx_summary(docx)
+  body_docx <- officer::docx_body_xml(docx)
 
-    expect_equal(
-      unlist(lapply(xml2::as_list(xml2::xml_find_all(body_docx, "//w:pgSz")), FUN = function(x) attr(x, "orient"))),
-      c("portrait", "landscape")
-    )
-  })
-}
+  # Need to check if both "table seq table" texts are in the docx file.
+  expect_true(grepl("Table SEQ Table", tmp_docx$text[1]))
+
+  expect_equal(
+    unlist(lapply(xml2::as_list(xml2::xml_find_all(body_docx, "//w:pgSz")), FUN = function(x) attr(x, "orient"))),
+    c("portrait", "landscape")
+  )
+})

--- a/tests/testthat/test-independent-testing-rtf_body.R
+++ b/tests/testthat/test-independent-testing-rtf_body.R
@@ -352,8 +352,8 @@ test_that("Case for page_by", {
 
 test_that("Case for using subline_by and page_by together", {
   tbl1 <- iris[c(1:4, 51:54), 3:5] |>
-    mutate(s2 = paste0(Species, 1:2), s3 = s2) |>
-    arrange(Species, s2) |>
+    dplyr::mutate(s2 = paste0(Species, 1:2), s3 = s2) |>
+    dplyr::arrange(Species, s2) |>
     rtf_body(
       subline_by = "Species",
       page_by = "s2"
@@ -382,8 +382,8 @@ test_that("Case for using subline_by and page_by together", {
 
 test_that("Case for using subline_by and page_by with pageby_row = 'first_row'", {
   tbl2 <- iris[c(1:4, 51:54), 3:5] |>
-    mutate(s2 = paste0(Species, 1:2), s3 = s2) |>
-    arrange(Species, s2) |>
+    dplyr::mutate(s2 = paste0(Species, 1:2), s3 = s2) |>
+    dplyr::arrange(Species, s2) |>
     rtf_body(
       subline_by = "Species",
       page_by = "s2",

--- a/tests/testthat/test-independent-testing-rtf_encode_table.R
+++ b/tests/testthat/test-independent-testing-rtf_encode_table.R
@@ -231,8 +231,8 @@ test_that("Test case when pageby$border_color_last is not NULL", {
 
 test_that("Test case when subline is not NULL", {
   ir3 <- iris[c(1:4, 51:54), 3:5] |>
-    mutate(s2 = paste0(Species, 1:2)) |>
-    arrange(Species, s2) |>
+    dplyr::mutate(s2 = paste0(Species, 1:2)) |>
+    dplyr::arrange(Species, s2) |>
     rtf_colheader("patelLength|patelWidth|s2") |>
     rtf_body(subline_by = "Species")
 
@@ -243,8 +243,8 @@ test_that("Test case when subline is not NULL", {
 
 test_that("Test case when subline is not NULL and verbose equals to TRUE", {
   ir3 <- iris[c(1:4, 51:54), 3:5] |>
-    mutate(s2 = paste0(Species, 1:2)) |>
-    arrange(Species, s2) |>
+    dplyr::mutate(s2 = paste0(Species, 1:2)) |>
+    dplyr::arrange(Species, s2) |>
     rtf_colheader("patelLength|patelWidth|s2") |>
     rtf_body(subline_by = "Species")
 
@@ -256,14 +256,14 @@ test_that("Test case when subline is not NULL and verbose equals to TRUE", {
 test_that("Test case when using subline_by, page_by, group_by simultaneously in rtf_body", {
   data(r2rtf_adae)
   ae_t1 <- r2rtf_adae[200:260, ] |>
-    mutate(
+    dplyr::mutate(
       SUBLINEBY = paste0(
         "Trial Number: ", STUDYID,
         ", Site Number: ", SITEID
       ),
     ) |>
-    select(USUBJID, ASTDY, AEDECOD, TRTA, SUBLINEBY) |>
-    arrange(SUBLINEBY, TRTA, USUBJID, ASTDY) |>
+    dplyr::select(USUBJID, ASTDY, AEDECOD, TRTA, SUBLINEBY) |>
+    dplyr::arrange(SUBLINEBY, TRTA, USUBJID, ASTDY) |>
     rtf_colheader("Subject| Rel Day | Adverse |") |>
     rtf_body(
       subline_by = "SUBLINEBY",
@@ -281,14 +281,14 @@ test_that("Test case when using subline_by, page_by, group_by simultaneously wit
   data(r2rtf_adae)
   ae_t2 <- r2rtf_adae[200:260, ] |>
     subset(USUBJID != "01-701-1442") |>
-    mutate(
+    dplyr::mutate(
       SUBLINEBY = paste0(
         "Trial Number: ", STUDYID,
         ", Site Number: ", SITEID
       ),
     ) |>
-    select(USUBJID, ASTDY, AEDECOD, TRTA, SUBLINEBY) |>
-    arrange(SUBLINEBY, TRTA, USUBJID, ASTDY) |>
+    dplyr::select(USUBJID, ASTDY, AEDECOD, TRTA, SUBLINEBY) |>
+    dplyr::arrange(SUBLINEBY, TRTA, USUBJID, ASTDY) |>
     rtf_colheader("Subject| Rel Day | Adverse |",
       border_bottom = "single"
     ) |>
@@ -309,14 +309,14 @@ test_that("Test case when using subline_by, page_by, group_by simultaneously wit
   data(r2rtf_adae)
   ae_t3 <- r2rtf_adae[200:260, ] |>
     subset(USUBJID != "01-701-1442") |>
-    mutate(
+    dplyr::mutate(
       SUBLINEBY = paste0(
         "Trial Number: ", STUDYID,
         ", Site Number: ", SITEID
       ),
     ) |>
-    select(USUBJID, ASTDY, AEDECOD, TRTA, SUBLINEBY) |>
-    arrange(SUBLINEBY, TRTA, USUBJID, ASTDY) |>
+    dplyr::select(USUBJID, ASTDY, AEDECOD, TRTA, SUBLINEBY) |>
+    dplyr::arrange(SUBLINEBY, TRTA, USUBJID, ASTDY) |>
     rtf_colheader("Subject| Rel Day | Adverse |",
       border_bottom = "single"
     ) |>

--- a/tests/testthat/test-independent-testing-rtf_nrow.R
+++ b/tests/testthat/test-independent-testing-rtf_nrow.R
@@ -1,5 +1,4 @@
 # create testing example
-svg(tempfile("tmp.svg"))
 
 font <- 2:3
 format <- matrix(c("", "i", "b", "ib"), nrow = 4, ncol = 2, byrow = FALSE)
@@ -174,5 +173,3 @@ test_that("test for rtf-nrow() if 'rtf-nrow' attributes are added correctly for 
 test_that("test for rtf-nrow() if 'rtf-nrow' attributes are added correctly for pageby_row table", {
   expect_equal(irspagebyrows[1], 1)
 })
-
-dev.off()

--- a/tests/testthat/test-independent-testing-rtf_pageby.R
+++ b/tests/testthat/test-independent-testing-rtf_pageby.R
@@ -1,5 +1,3 @@
-library(dplyr)
-
 test_that("Test case when page_by is NULL and new_page is TRUE", {
   expect_error(iris[1:2, ] |>
     rtf_body() |>
@@ -8,7 +6,7 @@ test_that("Test case when page_by is NULL and new_page is TRUE", {
 
 test_that("Test case when page_by is not NULL and data is sorted by the page_by variable", {
   expect_output(str(iris[1:2, ] |>
-    arrange(Petal.Length) |>
+    dplyr::arrange(Petal.Length) |>
     rtf_body() |>
     rtf_pageby(
       page_by = c("Petal.Length"), new_page = TRUE,
@@ -16,7 +14,7 @@ test_that("Test case when page_by is not NULL and data is sorted by the page_by 
     )), "2 obs")
 
   a <- iris[1:2, ] |>
-    arrange(Sepal.Width) |>
+    dplyr::arrange(Sepal.Width) |>
     rtf_body() |>
     rtf_pageby(
       page_by = c("Sepal.Width"), new_page = TRUE,
@@ -60,8 +58,8 @@ test_that("Test if there are more than one page_by variables", {
 # add tests for new features
 test_that("Test case when pageby_row='first_row'", {
   x <- iris[c(1:4, 51:54), 3:5] |>
-    mutate(s2 = paste0(Species, 1:2), s3 = s2) |>
-    arrange(Species, s2) |>
+    dplyr::mutate(s2 = paste0(Species, 1:2), s3 = s2) |>
+    dplyr::arrange(Species, s2) |>
     rtf_colheader("patelLength|patelWidth|s3") |>
     rtf_body(subline_by = "Species") |>
     rtf_pageby(
@@ -78,8 +76,8 @@ test_that("Test case when pageby_row='first_row'", {
 
 test_that("Test case when subline is not NULL", {
   x <- iris[c(1:4, 51:54), 3:5] |>
-    mutate(s2 = paste0(Species, 1:2), s3 = s2) |>
-    arrange(Species, s2) |>
+    dplyr::mutate(s2 = paste0(Species, 1:2), s3 = s2) |>
+    dplyr::arrange(Species, s2) |>
     rtf_colheader("patelLength|patelWidth|s3") |>
     rtf_body(subline_by = "Species") |>
     rtf_pageby(

--- a/tests/testthat/test-independent-testing-rtf_read_figure.R
+++ b/tests/testthat/test-independent-testing-rtf_read_figure.R
@@ -1,4 +1,3 @@
-library(dplyr)
 test_that("Test fig_format attribute", {
   a <- rtf_read_figure(c("fig/fig3.jpeg", "fig/fig2.png", "fig/fig4.emf"))
 


### PR DESCRIPTION
This PR updates all GitHub Actions workflows to their latest versions from upstream (r-lib/actions).

The upstream changes mostly involves updating `actions/checkout` and `actions/upload-artifact` to v4, which updated the default runtime to Node.js 20.

I just ran

```r
usethis::use_github_action("check-standard")
usethis::use_github_action("pkgdown")
usethis::use_github_action("test-coverage")
usethis::use_github_action("style")
```

Also, this fixes #213.