### PR TITLE
Some minor tweaks for convert()

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -43,7 +43,7 @@ jobs:
         with:
           extra-packages: |
             any::rcmdcheck
-            estimability=?ignore-before-r=4.3.0
+            emmeans=?ignore-before-r=4.3.0
           needs: check
 
       - uses: r-lib/actions/check-r-package@v2

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -41,7 +41,9 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::rcmdcheck
+          extra-packages: |
+            any::rcmdcheck
+            estimability=?ignore-before-r=4.3.0
           needs: check
 
       - uses: r-lib/actions/check-r-package@v2

--- a/R/conversion.R
+++ b/R/conversion.R
@@ -93,7 +93,7 @@ convert <- function(text,
 
   unicode_int <- as.integer(as.hexmode(unicode_latex$unicode))
   char_latex <- ifelse(unicode_int <= 255 & unicode_int != 177, unicode_latex$chr,
-    sprintf("\\uc1\\u%d*", unicode_int - ifelse (unicode_int < 32768, 0, 65536))
+    sprintf("\\uc1\\u%d*", unicode_int - ifelse(unicode_int < 32768, 0, 65536))
   )
 
   names(char_latex) <- unicode_latex$latex

--- a/R/conversion.R
+++ b/R/conversion.R
@@ -93,7 +93,7 @@ convert <- function(text,
 
   unicode_int <- as.integer(as.hexmode(unicode_latex$unicode))
   char_latex <- ifelse(unicode_int <= 255 & unicode_int != 177, unicode_latex$chr,
-    paste0("\\uc1\\u", unicode_int - if (unicode_int < 32768) 0 else 65536, "*")
+    sprintf("\\uc1\\u%d*", unicode_int - if (unicode_int < 32768) 0 else 65536)
   )
 
   names(char_latex) <- unicode_latex$latex

--- a/R/conversion.R
+++ b/R/conversion.R
@@ -70,7 +70,7 @@ cell_size <- function(col_rel_width, col_total_width) {
 #'
 #' @noRd
 convert <- function(text,
-                    load_stringi = class(try(stringi::stri_replace_all_fixed, silent = TRUE)) != "try-error") {
+                    load_stringi = requireNamespace("stringi", quietly = TRUE)) {
   # grepl(">|<|=|_|\\^|(\\\\)|(\\n)", c(">", "<", "=", "_", "\n", "\\line", "abc"))
   index <- grepl(">|<|=|_|\\^|(\\\\)|(\\n)", text)
 
@@ -91,12 +91,9 @@ convert <- function(text,
 
   # Define Pattern for latex code
 
-  unicode_latex$int <- as.integer(as.hexmode(unicode_latex$unicode))
-  char_latex <- ifelse(unicode_latex$int <= 255 & unicode_latex$int != 177, unicode_latex$chr,
-    ifelse(unicode_latex$int < 32768,
-      paste0("\\uc1\\u", unicode_latex$int, "*"),
-      paste0("\\uc1\\u", unicode_latex$int - 65536, "*")
-    )
+  unicode_int <- as.integer(as.hexmode(unicode_latex$unicode))
+  char_latex <- ifelse(unicode_int <= 255 & unicode_int != 177, unicode_latex$chr,
+    paste0("\\uc1\\u", unicode_int - if (unicode_int < 32768) 0 else 65536, "*")
   )
 
   names(char_latex) <- unicode_latex$latex
@@ -108,7 +105,7 @@ convert <- function(text,
       vectorize_all = FALSE, opts_fixed = list(case_insensitive = FALSE)
     )
   } else {
-    for (i in 1:length(char_latex)) {
+    for (i in seq_along(char_latex)) {
       text[index] <- gsub(names(char_latex[i]), char_latex[i], text[index], fixed = TRUE)
     }
   }

--- a/R/conversion.R
+++ b/R/conversion.R
@@ -93,7 +93,7 @@ convert <- function(text,
 
   unicode_int <- as.integer(as.hexmode(unicode_latex$unicode))
   char_latex <- ifelse(unicode_int <= 255 & unicode_int != 177, unicode_latex$chr,
-    sprintf("\\uc1\\u%d*", unicode_int - if (unicode_int < 32768) 0 else 65536)
+    sprintf("\\uc1\\u%d*", unicode_int - ifelse (unicode_int < 32768, 0, 65536))
   )
 
   names(char_latex) <- unicode_latex$latex


### PR DESCRIPTION
I'm proposing some minor changes while looking at #216 (these changes are irrelevant to #216, though):

1. Use `requireNamespace()` to test if **stringi** is available.
2. Reduce one `ifelse()` call.
3. Use the safer `seq_along(x)` instead of `1:length(x)`.