### PR TITLE
Update badge URL

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -11,7 +11,7 @@ output: github_document
 [![Codecov test coverage](https://codecov.io/gh/Merck/r2rtf/branch/master/graph/badge.svg)](https://app.codecov.io/gh/Merck/r2rtf?branch=master)
 [![CRAN Downloads](https://cranlogs.r-pkg.org/badges/r2rtf)](https://cran.r-project.org/package=r2rtf)
 [![R-CMD-check](https://github.com/Merck/r2rtf/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/Merck/r2rtf/actions/workflows/R-CMD-check.yaml)
-[![status](https://tinyverse.netlify.com/badge/r2rtf)](https://tinyverse.netlify.app/)
+[![status](https://tinyverse.netlify.app/badge/r2rtf)](https://cran.r-project.org/package=r2rtf)
 <!-- badges: end -->
 
 ```{r setup, include=FALSE}

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ coverage](https://codecov.io/gh/Merck/r2rtf/branch/master/graph/badge.svg)](http
 [![CRAN
 Downloads](https://cranlogs.r-pkg.org/badges/r2rtf)](https://cran.r-project.org/package=r2rtf)
 [![R-CMD-check](https://github.com/Merck/r2rtf/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/Merck/r2rtf/actions/workflows/R-CMD-check.yaml)
-[![status](https://tinyverse.netlify.com/badge/r2rtf)](https://tinyverse.netlify.app/)
+[![status](https://tinyverse.netlify.app/badge/r2rtf)](https://cran.r-project.org/package=r2rtf)
 <!-- badges: end -->
 
 ## Overview


### PR DESCRIPTION
This PR fixes the **tiny**verse badge URL as that has been changed from `netlify.com` to `netlify.app`.