### PR TITLE
Remove unnecessary `paste()` call

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -53,14 +53,11 @@ update_unicode_latex <- function() {
     "\\vec", "\\eqcolon", "\\square", "\\blacksquare"
   )), , drop = FALSE]
 
-  rows <- paste(
-    sprintf(
-      '"%s", "%s", %d',
-      tbl$unicode,
-      gsub("\\", "\\\\", tbl$latex, fixed = TRUE),
-      tbl$int
-    ),
-    sep = ", "
+  rows <- sprintf(
+    '"%s", "%s", %d',
+    tbl$unicode,
+    gsub("\\", "\\\\", tbl$latex, fixed = TRUE),
+    tbl$int
   )
 
   writeLines(c(


### PR DESCRIPTION
A follow up to #223 - this PR removes the unnecessary `paste()` call from `update_unicode_latex()` as `sprintf()` is already sufficient.