### PR TITLE
Update news for r2rtf 1.1.2

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -11,9 +11,9 @@ authors:
   given-names: "Fansen"
 - family-names: "Lang"
   given-names: "Brian"
-title: "r2rtf: Easily Create Production-Ready Rich Text Format (RTF) Table and Figure"
-version: 1.0.1
-date-released: 2020-02-19
+title: "r2rtf: Easily Create Production-Ready Rich Text Format (RTF) Tables and Figures"
+version: 1.1.2
+date-released: 2024-05-28
 url: "https://github.com/Merck/r2rtf"
 preferred-citation:
   type: conference-paper

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: r2rtf
-Title: Easily Create Production-Ready Rich Text Format (RTF) Table and Figure
-Version: 1.1.1
+Title: Easily Create Production-Ready Rich Text Format (RTF) Tables and Figures
+Version: 1.1.2
 Authors@R: c(
     person("Yilong", "Zhang", role = "aut"),
     person("Siruo", "Wang", role = "aut"),
@@ -20,11 +20,12 @@ Authors@R: c(
     person("Jeff", "Cheng", role = "ctb"),
     person("Yirong", "Cao", role = "ctb"),
     person("Amin", "Shirazi", role = "ctb"),
+    person("Yihui", "Xie", role = "ctb"),
     person("Günter", "Milde", role = c("ctb"),
            comment = c("Original author of the unimathsymbols.txt file")),
     person("Merck Sharp & Dohme Corp", role = "cph")
     )
-Description: Create production-ready Rich Text Format (RTF) table and figure
+Description: Create production-ready Rich Text Format (RTF) tables and figures
     with flexible format.
 License: GPL-3
 URL: https://merck.github.io/r2rtf/, https://github.com/Merck/r2rtf

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,13 @@
+# r2rtf 1.1.2
+
+## Improvements
+
+* Fine-tune the symbol to ANSI and Unicode converter for faster, safer, and
+  more robust conversion (thanks, @yihui, #217).
+* Use code to generate the Unicode/LaTeX mapping table, to replace the previous
+  `R/sysdata.rda` solution. Now the mapping table is directly accessible
+  via `r2rtf:::unicode_latex` (thanks, @yihui, #218).
+
 # r2rtf 1.1.1
 
 ## Bug fixes

--- a/README.Rmd
+++ b/README.Rmd
@@ -55,7 +55,7 @@ remotes::install_github("Merck/r2rtf")
 
 The R package r2rtf provides flexibility to enable features below:
 
-- Create highly customized RTF table and figure ready for production.
+- Create highly customized RTF tables and figures ready for production.
 - Simple to use parameters and data structure.
   - Customized column header: split by `"|"`.
   - Three required parameters for the output tables (data, filename, column relative width).

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ remotes::install_github("Merck/r2rtf")
 
 The R package r2rtf provides flexibility to enable features below:
 
-- Create highly customized RTF table and figure ready for production.
+- Create highly customized RTF tables and figures ready for production.
 - Simple to use parameters and data structure.
   - Customized column header: split by `"|"`.
   - Three required parameters for the output tables (data, filename,


### PR DESCRIPTION
This PR updates the changelog for r2rtf 1.1.2.

Also improves titles involving "tables and figures" by using the plural form.