### PR TITLE
Add libreoffice 24.8 and 24.2 support

### DIFF
--- a/R/rtf_convert_format.R
+++ b/R/rtf_convert_format.R
@@ -46,6 +46,7 @@ rtf_convert_format <- function(input,
       paste0(
         "libreoffice",
         c(
+          "24.8", "24.2",
           "7.6", "7.5", "7.4", "7.3", "7.2", "7.1"
         )
       ),


### PR DESCRIPTION
This PR adds libreoffice 24.8 and 24.2 support to the internal format converter function.

In case you wonder why the big version jump from 7.x to 24.x: libreoffice has switched to calendar versioning.