### PR TITLE
Fix `unlist()` usage in `as_rtf_footnote()` under R >= 4.5.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: r2rtf
 Title: Easily Create Production-Ready Rich Text Format (RTF) Tables and Figures
-Version: 1.1.2
+Version: 1.1.2.9000
 Authors@R: c(
     person("Yilong", "Zhang", role = "aut"),
     person("Siruo", "Wang", role = "aut"),
@@ -52,4 +52,4 @@ Suggests:
     xml2
 Config/testthat/edition: 3
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# r2rtf 1.1.2.9000
+
+## Bug fixes
+
+- Fix `unlist()` usage in `as_rtf_footnote()` which could result in errors
+  for downstream code under R >= 4.5.0 (@nanxstats, #245).
+
 # r2rtf 1.1.2
 
 ## Improvements

--- a/R/content_create.R
+++ b/R/content_create.R
@@ -295,11 +295,11 @@ as_rtf_footnote <- function(tbl, attr_name = "rtf_footnote") {
   }
 
   if (attr(text, "as_table")) {
-    indent <- unlist(
+    indent <- unlist(c(
       attr(text, "text_indent_first"),
       attr(text, "text_indent_left"),
       attr(text, "text_indent_right")
-    )
+    ))
 
     if (any(indent != 0)) {
       text_matrix <- matrix(text, ncol = 1)


### PR DESCRIPTION
Fixes #244 

This PR corrects the `unlist()` usage in `as_rtf_footnote()` by bundling the inputs first with `c()`.

With the patch, the check errors in gsDesign and metalite.ae seem to be resolved using r-devel locally.