### PR TITLE
Update GHA workflows

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -4,9 +4,8 @@ on:
   push:
     branches: [main, master]
   pull_request:
-    branches: [main, master]
 
-name: R-CMD-check
+name: R-CMD-check.yaml
 
 permissions: read-all
 

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -4,12 +4,11 @@ on:
   push:
     branches: [main, master]
   pull_request:
-    branches: [main, master]
   release:
     types: [published]
   workflow_dispatch:
 
-name: pkgdown
+name: pkgdown.yaml
 
 permissions: read-all
 

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -4,7 +4,7 @@ on:
   push:
     paths: ["**.[rR]", "**.[qrR]md", "**.[rR]markdown", "**.[rR]nw", "**.[rR]profile"]
 
-name: Style
+name: style.yaml
 
 permissions: read-all
 
@@ -26,11 +26,10 @@ jobs:
         with:
           use-public-rspm: true
 
-      - name: Install dependencies
+      - name: Install styler and roxygen2
         uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::styler, any::roxygen2
-          needs: styler
+          packages: styler, roxygen2
 
       - name: Enable styler cache
         run: styler::cache_activate()

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -4,9 +4,8 @@ on:
   push:
     branches: [main, master]
   pull_request:
-    branches: [main, master]
 
-name: test-coverage
+name: test-coverage.yaml
 
 permissions: read-all
 
@@ -15,7 +14,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
     steps:
       - uses: actions/checkout@v4
@@ -26,19 +24,28 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::covr
+          extra-packages: any::covr, any::xml2
           needs: coverage
 
       - name: Test coverage
         run: |
-          token <- Sys.getenv("CODECOV_TOKEN", "")
-          covr::codecov(
+          cov <- covr::package_coverage(
             quiet = FALSE,
             clean = FALSE,
-            install_path = file.path(normalizePath(Sys.getenv("RUNNER_TEMP"), winslash = "/"), "package"),
-            token = if (token != "") token
+            install_path = file.path(normalizePath(Sys.getenv("RUNNER_TEMP"), winslash = "/"), "package")
           )
+          print(cov)
+          covr::to_cobertura(cov)
         shell: Rscript {0}
+
+      - uses: codecov/codecov-action@v4
+        with:
+          # Fail if error if not on PR, or if on PR and token is given
+          fail_ci_if_error: ${{ github.event_name != 'pull_request' || secrets.CODECOV_TOKEN }}
+          file: ./cobertura.xml
+          plugin: noop
+          disable_search: true
+          token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Show testthat output
         if: always()

--- a/README.Rmd
+++ b/README.Rmd
@@ -8,7 +8,7 @@ output: github_document
 
 <!-- badges: start -->
 [![CRAN status](https://www.r-pkg.org/badges/version/r2rtf)](https://CRAN.R-project.org/package=r2rtf)
-[![Codecov test coverage](https://codecov.io/gh/Merck/r2rtf/branch/master/graph/badge.svg)](https://app.codecov.io/gh/Merck/r2rtf?branch=master)
+[![Codecov test coverage](https://codecov.io/gh/Merck/r2rtf/graph/badge.svg)](https://app.codecov.io/gh/Merck/r2rtf)
 [![CRAN Downloads](https://cranlogs.r-pkg.org/badges/r2rtf)](https://cran.r-project.org/package=r2rtf)
 [![R-CMD-check](https://github.com/Merck/r2rtf/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/Merck/r2rtf/actions/workflows/R-CMD-check.yaml)
 [![status](https://tinyverse.netlify.app/badge/r2rtf)](https://cran.r-project.org/package=r2rtf)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![CRAN
 status](https://www.r-pkg.org/badges/version/r2rtf)](https://CRAN.R-project.org/package=r2rtf)
 [![Codecov test
-coverage](https://codecov.io/gh/Merck/r2rtf/branch/master/graph/badge.svg)](https://app.codecov.io/gh/Merck/r2rtf?branch=master)
+coverage](https://codecov.io/gh/Merck/r2rtf/graph/badge.svg)](https://app.codecov.io/gh/Merck/r2rtf)
 [![CRAN
 Downloads](https://cranlogs.r-pkg.org/badges/r2rtf)](https://cran.r-project.org/package=r2rtf)
 [![R-CMD-check](https://github.com/Merck/r2rtf/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/Merck/r2rtf/actions/workflows/R-CMD-check.yaml)
@@ -83,9 +83,12 @@ head(iris) %>%
 ```
 
 <details>
+
 <summary>
+
 Click here to see the output
 </summary>
+
 <img src="https://merck.github.io/r2rtf/articles/fig/ex-tbl.png">
 </details>
 
@@ -97,9 +100,12 @@ Click here to see the output
   code](https://merck.github.io/r2rtf/articles/example-efficacy.html)
 
 <details>
+
 <summary>
+
 Click here to see the output
 </summary>
+
 <img src="https://merck.github.io/r2rtf/articles/fig/efficacy_example.png">
 </details>
 
@@ -109,9 +115,12 @@ Click here to see the output
   code](https://merck.github.io/r2rtf/articles/example-ae-summary.html)
 
 <details>
+
 <summary>
+
 Click here to see the output
 </summary>
+
 <img src="https://merck.github.io/r2rtf/articles/fig/ae_example.png">
 </details>
 


### PR DESCRIPTION
This PR updates the GitHub Actions workflows to the latest versions from upstream.

```r
usethis::use_github_action("check-standard")
usethis::use_github_action("pkgdown")
usethis::use_github_action("style")
usethis::use_github_action("test-coverage")
```