### PR TITLE
Safeguard code examples and tests where dependencies of officer (systemfonts) could be missing

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: r2rtf
 Title: Easily Create Production-Ready Rich Text Format (RTF) Tables and Figures
-Version: 1.1.3
+Version: 1.1.3.9000
 Authors@R: c(
     person("Yilong", "Zhang", role = "aut"),
     person("Siruo", "Wang", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# r2rtf 1.1.3.9000
+
+## Improvements
+
+- Safeguard code examples and tests against a rare situation where officer
+  could miss its underlying dependency systemfonts (@nanxstats, #249).
+
 # r2rtf 1.1.3
 
 ## Bug fixes

--- a/R/assemble.R
+++ b/R/assemble.R
@@ -100,7 +100,7 @@ assemble_rtf <- function(input,
 #' The contents of this section are shown in PDF user manual only.
 #' }
 #'
-#' @examplesIf requireNamespace("officer", quietly = TRUE) && requireNamespace("systemfonts", quietly = TRUE)
+#' @examplesIf is_installed("officer") && is_installed("systemfonts")
 #'
 #' library(officer)
 #' library(magrittr)

--- a/R/assemble.R
+++ b/R/assemble.R
@@ -100,7 +100,7 @@ assemble_rtf <- function(input,
 #' The contents of this section are shown in PDF user manual only.
 #' }
 #'
-#' @examplesIf is_installed("officer") && is_installed("systemfonts")
+#' @examplesIf r2rtf:::is_installed("officer") && r2rtf:::is_installed("systemfonts")
 #'
 #' library(officer)
 #' library(magrittr)

--- a/R/assemble.R
+++ b/R/assemble.R
@@ -100,7 +100,7 @@ assemble_rtf <- function(input,
 #' The contents of this section are shown in PDF user manual only.
 #' }
 #'
-#' @examples
+#' @examplesIf requireNamespace("officer", quietly = TRUE) && requireNamespace("systemfonts", quietly = TRUE)
 #'
 #' library(officer)
 #' library(magrittr)

--- a/R/staticimports.R
+++ b/R/staticimports.R
@@ -1,0 +1,67 @@
+# These functions:
+# - `is_installed()`
+# - `get_package_version()`
+# - `system_file_cached()`
+# were sourced from the staticimports package version 0.0.0.9001, available at
+# <https://github.com/wch/staticimports>.
+#
+# For the original version of these functions, please see:
+# <https://github.com/wch/staticimports/blob/35ceec8d9d9429d9244aedc3ee6a1e8d62d59f79/inst/staticexports/package.R>.
+#
+# The staticimports package is licensed under the MIT license.
+# For more details on the license, see
+# <https://github.com/wch/staticimports/blob/35ceec8d9d9429d9244aedc3ee6a1e8d62d59f79/LICENSE.md>.
+
+is_installed <- function(pkg, version = NULL) {
+  installed <- isNamespaceLoaded(pkg) || nzchar(system_file_cached(package = pkg))
+
+  if (is.null(version)) {
+    return(installed)
+  }
+
+  if (!is.character(version) && !inherits(version, "numeric_version")) {
+    # Avoid https://bugs.r-project.org/show_bug.cgi?id=18548
+    alert <- if (identical(Sys.getenv("TESTTHAT"), "true")) stop else warning
+    alert("`version` must be a character string or a `package_version` or `numeric_version` object.")
+
+    version <- numeric_version(sprintf("%0.9g", version))
+  }
+
+  installed && isTRUE(get_package_version(pkg) >= version)
+}
+
+get_package_version <- function(pkg) {
+  # `utils::packageVersion()` can be slow, so first try the fast path of
+  # checking if the package is already loaded.
+  ns <- .getNamespace(pkg)
+  if (is.null(ns)) {
+    utils::packageVersion(pkg)
+  } else {
+    as.package_version(ns$.__NAMESPACE__.$spec[["version"]])
+  }
+}
+
+# A wrapper for `system.file()`, which caches the package path because
+# `system.file()` can be slow. If a package is not installed, the result won't
+# be cached.
+system_file_cached <- local({
+  pkg_dir_cache <- character()
+
+  function(..., package = "base") {
+    if (!is.null(names(list(...)))) {
+      stop("All arguments other than `package` must be unnamed.")
+    }
+
+    not_cached <- is.na(match(package, names(pkg_dir_cache)))
+    if (not_cached) {
+      pkg_dir <- system.file(package = package)
+      if (nzchar(pkg_dir)) {
+        pkg_dir_cache[[package]] <<- pkg_dir
+      }
+    } else {
+      pkg_dir <- pkg_dir_cache[[package]]
+    }
+
+    file.path(pkg_dir, ...)
+  }
+})

--- a/man/assemble_docx.Rd
+++ b/man/assemble_docx.Rd
@@ -31,6 +31,7 @@ The contents of this section are shown in PDF user manual only.
 }
 
 \examples{
+\dontshow{if (requireNamespace("officer", quietly = TRUE) && requireNamespace("systemfonts", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 
 library(officer)
 library(magrittr)
@@ -51,5 +52,5 @@ assemble_docx(
   input = file,
   output = output
 )
-
+\dontshow{\}) # examplesIf}
 }

--- a/man/assemble_docx.Rd
+++ b/man/assemble_docx.Rd
@@ -31,7 +31,7 @@ The contents of this section are shown in PDF user manual only.
 }
 
 \examples{
-\dontshow{if (requireNamespace("officer", quietly = TRUE) && requireNamespace("systemfonts", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (is_installed("officer") && is_installed("systemfonts")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 
 library(officer)
 library(magrittr)

--- a/man/assemble_docx.Rd
+++ b/man/assemble_docx.Rd
@@ -31,7 +31,7 @@ The contents of this section are shown in PDF user manual only.
 }
 
 \examples{
-\dontshow{if (is_installed("officer") && is_installed("systemfonts")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (r2rtf:::is_installed("officer") && r2rtf:::is_installed("systemfonts")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 
 library(officer)
 library(magrittr)

--- a/tests/testthat/test-independent-testing-assemble.R
+++ b/tests/testthat/test-independent-testing-assemble.R
@@ -48,6 +48,7 @@ test_that("rtf_assemble: output without using officer", {
 # test functionality with officer
 test_that("rtf_assemble: output with using officer", {
   skip_if_not_installed("officer")
+  skip_if_not_installed("systemfonts")
 
   file_tmp <- tempfile(fileext = ".docx")
   rtf_path <- assemble_docx(


### PR DESCRIPTION
## Problem

r2rtf suggests officer as a soft dependency and uses it in examples and tests. officer imports ragg, which imports systemfonts.

The current version of systemfonts (1.2.1) on CRAN has some C++ issues that fails to build on r-oldrel-macos-arm64. This makes r2rtf fail to pass the check on that platform:

```text
Version: 1.1.3
Check: examples
Result: ERROR
  Running examples in ‘r2rtf-Ex.R’ failed
  The error most likely occurred in:

  > ### Name: assemble_docx
  > ### Title: Assemble Multiple RTF Table Listing and Figure Into One Word
  > ###   Document
  > ### Aliases: assemble_docx
  >
  > ### ** Examples
  >
  >
  > library(officer)
  Error: package or namespace load failed for ‘officer’ in loadNamespace(j <- i[[1L]], c(lib.loc, .libPaths()), versionCheck = vI[[j]]):
   there is no package called ‘systemfonts’
  Execution halted
Flavor: r-oldrel-macos-arm64
```

## Solution

This PR safeguards the relevant code examples and tests against this rare situation so it can pass the check on all platforms on CRAN.

I introduced `is_installed()` from staticimports to detect if a package has been installed. This is because 1. We want to avoid introducing rlang as a dependency. 2. If we use the base R solution `requireNamespace()`, it will generate this check warning:

```text
* checking for unstated dependencies in examples ... WARNING
'library' or 'require' call not declared from: 'systemfonts'
```