### PR TITLE
bug fix #251: text color

### DIFF
--- a/R/rtf_encode_figure.R
+++ b/R/rtf_encode_figure.R
@@ -71,6 +71,7 @@ rtf_encode_figure <- function(tbl) {
   start_rtf <- paste(
     as_rtf_init(),
     as_rtf_font(),
+    as_rtf_color(tbl),
     sep = "\n"
   )
 


### PR DESCRIPTION
Fixes #251

Fix bug when encode figures into rtf reported in #251 

## Code: 

```r
library(dplyr)
library(r2rtf)

png("image3.png")
plot(1:10)
dev.off()

## where filename holds a list of pngs which are found in the current wd.
filename <- c("image1.png", "image2.png", "image3.png")

## where the rtf you want to produce is called figures.rtf
rtf_filename <- "figures.rtf"

filename %>%
  rtf_read_figure() %>%
  rtf_page(
    orientation = "landscape", margin = c(0.5, 0.5, 1, 1, 0.5, 0.5),
    use_color = TRUE
  ) %>%
  rtf_page_header(
    text = c(
      "header1",
      "header2"
    ),
    text_font = 9, text_justification = c("r", "l"),
    text_font_size = 9, text_space_before = 0, text_space_after = 0
  ) %>%
  rtf_title(
    title = c("title1", "title2"),
    text_font = 9, text_font_size = 9,
    text_color = "red", text_convert = FALSE
  ) %>%
  rtf_page_footer(
    text = c("footnote1", "footnote2"),
    text_font_size = 9, text_font = 9,
    text_justification = "l", text_convert = FALSE
  ) %>%
  rtf_figure(fig_height = 5, fig_width = 10.2) %>%
  rtf_encode(doc_type = "figure") %>%
  write_rtf(file = rtf_filename)
```

## Result

![image](https://github.com/user-attachments/assets/6ac9f689-3ff0-443b-b8ce-be1c3723cb44)
