### PR TITLE
Update news for v1.1.4

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: r2rtf
 Title: Easily Create Production-Ready Rich Text Format (RTF) Tables and Figures
-Version: 1.1.3.9000
+Version: 1.1.4
 Authors@R: c(
     person("Yilong", "Zhang", role = "aut"),
     person("Siruo", "Wang", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,9 @@
-# r2rtf 1.1.3.9000
+# r2rtf 1.1.4
+
+## Bug fixes
+
+- Support setting text color properly when encoding figures into RTF
+  (@elong0527, #252).
 
 ## Improvements
 


### PR DESCRIPTION
This PR bumps the version number to 1.1.4 and updates `NEWS.md` to prepare for the incoming release.