### PR TITLE
Prevent `strwidth()` and `par()` calls from leaking graphics devices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,9 +5,7 @@ docs
 .RData
 doc
 Meta
-sync_bitbucket.R
 r2rtf.Rcheck/
 r2rtf*.tar.gz
 r2rtf*.tgz
 revdep/
-Rplots.pdf

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,17 @@
+# r2rtf 1.2.0.9000
+
+## Bug fixes
+
+- `strwidth()` and `par()` calls no longer leak a graphics device when
+  no device is active, preventing unwanted `Rplots.pdf` output (#285).
+
 # r2rtf 1.2.0
 
 ## New features
 
-- Add internationalization (i18n) support with `use_i18n` parameter in `rtf_page()` 
+- Add internationalization (i18n) support with `use_i18n` parameter in `rtf_page()`
   to enable SimSun font for Chinese character support in RTF documents (#256).
-- Add `text_hyphenation` parameter to `rtf_title()`, `rtf_colheader()`, and 
+- Add `text_hyphenation` parameter to `rtf_title()`, `rtf_colheader()`, and
   `rtf_subline()` functions to control text hyphenation in RTF output (#235).
 
 ## Improvements

--- a/R/rtf_strwidth.R
+++ b/R/rtf_strwidth.R
@@ -53,7 +53,7 @@ rtf_strwidth <- function(tbl) {
   }
 
   # Font size
-  text_cex <- attr(tbl, "text_font_size") / graphics::par("ps")
+  text_cex <- attr(tbl, "text_font_size") / with_graphics_device(graphics::par("ps"))
 
   # Font format
   # text format 1 (plain/normal), 2 (bold), 3 (italic), 4 (bold-italic)
@@ -110,12 +110,13 @@ rtf_strwidth <- function(tbl) {
       grDevices::windowsFonts("Courier" = grDevices::windowsFont("Courier New"))
     }
 
-    x$width <- graphics::strwidth(x$text,
+    x$width <- with_graphics_device(graphics::strwidth(
+      x$text,
       units = "inches",
       cex = x$cex[1],
       font = x$font[1],
       family = as.character(x$family[1])
-    )
+    ))
     x
   })
   db <- do.call(rbind, db_list)

--- a/R/safe_graphics.R
+++ b/R/safe_graphics.R
@@ -27,7 +27,10 @@ with_graphics_device <- function(expr) {
 #' Open a file-backed device (prefer the session default) targeting the
 #' platform null file so no output is created on disk.
 #'
-#' @returns The opened device number (or 1 if opening failed).
+#' @returns The device number returned by [grDevices::dev.cur()] after the
+#'   attempt. If no device could be opened, this will be `1` (the null device;
+#'   i.e., no active device), which is safe because `close_device()` treats `1`
+#'   as a no-op.
 #'
 #' @noRd
 open_null_device <- function() {

--- a/R/safe_graphics.R
+++ b/R/safe_graphics.R
@@ -1,0 +1,84 @@
+#' Evaluate graphics code without leaking devices
+#'
+#' Functions like [graphics::strwidth()] and [graphics::par()] require an
+#' active graphics device. When no device is active, they may implicitly
+#' open the default device (for example, [grDevices::pdf()]), which can
+#' leave a device open and/or create `Rplots.*` files.
+#'
+#' This helper evaluates an expression with an active device and restores the
+#' original device state on exit.
+#'
+#' @noRd
+with_graphics_device <- function(expr) {
+  expr <- substitute(expr)
+
+  if (!is.null(grDevices::dev.list())) {
+    return(eval(expr, envir = parent.frame()))
+  }
+
+  opened_device <- open_null_device()
+  on.exit(close_device(opened_device), add = TRUE)
+
+  eval(expr, envir = parent.frame())
+}
+
+#' Open a null device
+#'
+#' Open a file-backed device (prefer the session default) targeting the
+#' platform null file so no output is created on disk.
+#'
+#' @returns The opened device number (or 1 if opening failed).
+#'
+#' @noRd
+open_null_device <- function() {
+  null_file <- file_null()
+  device_opt <- getOption("device")
+
+  device_fun <- NULL
+  if (is.function(device_opt)) {
+    device_fun <- device_opt
+  } else if (is.character(device_opt) && length(device_opt) == 1L) {
+    device_fun <- get(device_opt, mode = "function")
+  }
+
+  if (is.function(device_fun)) {
+    arg_names <- tryCatch(names(formals(device_fun)), error = function(e) NULL)
+    if (!is.null(arg_names)) {
+      tryCatch(
+        suppressWarnings(
+          suppressMessages(
+            if ("file" %in% arg_names) {
+              device_fun(file = null_file)
+            } else if ("filename" %in% arg_names) {
+              device_fun(filename = null_file)
+            }
+          )
+        ),
+        error = function(e) NULL
+      )
+    }
+  }
+
+  if (is.null(grDevices::dev.list())) {
+    suppressWarnings(suppressMessages(grDevices::pdf(file = null_file)))
+  }
+
+  grDevices::dev.cur()
+}
+
+close_device <- function(which) {
+  if (!is.numeric(which) || length(which) != 1L || is.na(which) || which == 1L) {
+    return(invisible(NULL))
+  }
+
+  open_devices <- grDevices::dev.list()
+  if (!is.null(open_devices) && which %in% open_devices) {
+    grDevices::dev.off(which)
+  }
+
+  invisible(NULL)
+}
+
+file_null <- function() {
+  if (.Platform$OS.type == "windows") "nul:" else "/dev/null"
+}

--- a/R/safe_graphics.R
+++ b/R/safe_graphics.R
@@ -27,6 +27,10 @@ with_graphics_device <- function(expr) {
 #' Open a file-backed device (prefer the session default) targeting the
 #' platform null file so no output is created on disk.
 #'
+#' This first tries to use the session default device from `getOption("device")`
+#' when it supports a `file` or `filename` argument. If that does not result in
+#' an open device, it falls back to [grDevices::pdf()] writing to the null file.
+#'
 #' @returns The device number returned by [grDevices::dev.cur()] after the
 #'   attempt. If no device could be opened, this will be `1` (the null device;
 #'   i.e., no active device), which is safe because `close_device()` treats `1`

--- a/R/safe_graphics.R
+++ b/R/safe_graphics.R
@@ -41,7 +41,10 @@ open_null_device <- function() {
   if (is.function(device_opt)) {
     device_fun <- device_opt
   } else if (is.character(device_opt) && length(device_opt) == 1L) {
-    device_fun <- get(device_opt, mode = "function")
+    device_fun <- tryCatch(
+      get(device_opt, mode = "function"),
+      error = function(e) NULL
+    )
   }
 
   if (is.function(device_fun)) {

--- a/tests/testthat/test-independent-testing-rtf_nrow.R
+++ b/tests/testthat/test-independent-testing-rtf_nrow.R
@@ -76,8 +76,8 @@ cellsize <- matrix(width, nrow = nrow(tbl), ncol = ncol(tbl), byrow = TRUE) - pa
 nline_vector <- rtf_nline_vector(
   text = c("title 1", "this is a sentence for title 2", NA),
   strwidth = c(
-    strwidth("title 1", units = "inches"),
-    strwidth("this is a sentence for title 2", units = "inches")
+    with_graphics_device(graphics::strwidth("title 1", units = "inches")),
+    with_graphics_device(graphics::strwidth("this is a sentence for title 2", units = "inches"))
   ),
   size = 0.5
 )

--- a/tests/testthat/test-independent-testing-rtf_nrow.R
+++ b/tests/testthat/test-independent-testing-rtf_nrow.R
@@ -76,8 +76,8 @@ cellsize <- matrix(width, nrow = nrow(tbl), ncol = ncol(tbl), byrow = TRUE) - pa
 nline_vector <- rtf_nline_vector(
   text = c("title 1", "this is a sentence for title 2", NA),
   strwidth = c(
-    with_graphics_device(graphics::strwidth("title 1", units = "inches")),
-    with_graphics_device(graphics::strwidth("this is a sentence for title 2", units = "inches"))
+    r2rtf:::with_graphics_device(graphics::strwidth("title 1", units = "inches")),
+    r2rtf:::with_graphics_device(graphics::strwidth("this is a sentence for title 2", units = "inches"))
   ),
   size = 0.5
 )

--- a/tests/testthat/test-independent-testing-rtf_strwidth.R
+++ b/tests/testthat/test-independent-testing-rtf_strwidth.R
@@ -15,7 +15,7 @@ tbl <- df |>
 
 strw <- round(r2rtf:::rtf_strwidth(tbl), 5)
 
-size8italic <- round(with_graphics_device(graphics::strwidth(
+size8italic <- round(r2rtf:::with_graphics_device(graphics::strwidth(
   "This is a long sentence",
   units = "inches",
   cex = 2 / 3,
@@ -23,7 +23,7 @@ size8italic <- round(with_graphics_device(graphics::strwidth(
   family = "Times"
 )), 5)
 
-bold <- round(with_graphics_device(graphics::strwidth(
+bold <- round(r2rtf:::with_graphics_device(graphics::strwidth(
   "third",
   units = "inches",
   cex = 2 / 3,

--- a/tests/testthat/test-independent-testing-rtf_strwidth.R
+++ b/tests/testthat/test-independent-testing-rtf_strwidth.R
@@ -15,19 +15,21 @@ tbl <- df |>
 
 strw <- round(r2rtf:::rtf_strwidth(tbl), 5)
 
-size8italic <- round(graphics::strwidth("This is a long sentence",
+size8italic <- round(with_graphics_device(graphics::strwidth(
+  "This is a long sentence",
   units = "inches",
   cex = 2 / 3,
   font = 3,
   family = "Times"
-), 5)
+)), 5)
 
-bold <- round(graphics::strwidth("third",
+bold <- round(with_graphics_device(graphics::strwidth(
+  "third",
   units = "inches",
   cex = 2 / 3,
   font = 2,
   family = "Times"
-), 5)
+)), 5)
 
 
 test_that("test if width are calculated correctly for case when font size is 8", {

--- a/tests/testthat/test-independent-testing-safe_graphics.R
+++ b/tests/testthat/test-independent-testing-safe_graphics.R
@@ -1,0 +1,137 @@
+safe_device_ids <- function() {
+  devices <- grDevices::dev.list()
+  if (is.null(devices)) integer() else unname(devices)
+}
+
+close_new_devices <- function(before_ids) {
+  after_ids <- safe_device_ids()
+  new_ids <- setdiff(after_ids, before_ids)
+  if (length(new_ids) > 0) {
+    for (id in new_ids) {
+      grDevices::dev.off(id)
+    }
+  }
+  invisible(new_ids)
+}
+
+test_that("file_null returns the platform null device", {
+  expected <- if (.Platform$OS.type == "windows") "nul:" else "/dev/null"
+  expect_identical(r2rtf:::file_null(), expected)
+})
+
+test_that("close_device ignores invalid identifiers", {
+  before <- safe_device_ids()
+  r2rtf:::close_device(NA_real_)
+  r2rtf:::close_device("not-a-device")
+  r2rtf:::close_device(1)
+  r2rtf:::close_device(9999)
+  expect_identical(safe_device_ids(), before)
+})
+
+test_that("close_device closes a live device", {
+  before <- safe_device_ids()
+  on.exit(close_new_devices(before), add = TRUE)
+
+  grDevices::pdf(file = r2rtf:::file_null())
+  new_ids <- setdiff(safe_device_ids(), before)
+
+  expect_true(length(new_ids) >= 1)
+
+  r2rtf:::close_device(new_ids[1])
+
+  expect_identical(safe_device_ids(), before)
+})
+
+test_that("with_graphics_device restores device state", {
+  before <- safe_device_ids()
+  on.exit(close_new_devices(before), add = TRUE)
+
+  width <- r2rtf:::with_graphics_device({
+    graphics::plot.new()
+    graphics::strwidth("x")
+  })
+
+  expect_true(is.numeric(width))
+  expect_identical(safe_device_ids(), before)
+})
+
+test_that("with_graphics_device does not add devices when one is active", {
+  before <- safe_device_ids()
+  on.exit(close_new_devices(before), add = TRUE)
+
+  grDevices::pdf(file = r2rtf:::file_null())
+  open_devices <- safe_device_ids()
+
+  width <- r2rtf:::with_graphics_device({
+    graphics::plot.new()
+    graphics::strwidth("x")
+  })
+
+  expect_true(is.numeric(width))
+  expect_identical(safe_device_ids(), open_devices)
+})
+
+test_that("open_null_device honors device option with file", {
+  before <- safe_device_ids()
+  on.exit(close_new_devices(before), add = TRUE)
+
+  old_device <- getOption("device")
+  on.exit(options(device = old_device), add = TRUE)
+
+  called <- FALSE
+  file_arg <- NULL
+  device_fun <- function(file, ...) {
+    called <<- TRUE
+    file_arg <<- file
+    grDevices::pdf(file = file, ...)
+  }
+  options(device = device_fun)
+
+  opened <- r2rtf:::open_null_device()
+
+  expect_true(called)
+  expect_identical(file_arg, r2rtf:::file_null())
+  expect_true(opened %in% safe_device_ids())
+})
+
+test_that("open_null_device honors device option with filename", {
+  before <- safe_device_ids()
+  on.exit(close_new_devices(before), add = TRUE)
+
+  old_device <- getOption("device")
+  on.exit(options(device = old_device), add = TRUE)
+
+  called <- FALSE
+  filename_arg <- NULL
+  device_fun <- function(filename, ...) {
+    called <<- TRUE
+    filename_arg <<- filename
+    grDevices::pdf(file = filename, ...)
+  }
+  options(device = device_fun)
+
+  opened <- r2rtf:::open_null_device()
+
+  expect_true(called)
+  expect_identical(filename_arg, r2rtf:::file_null())
+  expect_true(opened %in% safe_device_ids())
+})
+
+test_that("open_null_device falls back when option cannot accept a file", {
+  before <- safe_device_ids()
+  if (length(before) > 0) {
+    skip("requires no active devices for fallback path")
+  }
+  on.exit(close_new_devices(before), add = TRUE)
+
+  old_device <- getOption("device")
+  on.exit(options(device = old_device), add = TRUE)
+
+  options(device = function(...) NULL)
+
+  opened <- r2rtf:::open_null_device()
+
+  after <- safe_device_ids()
+  expect_true(length(after) >= 1)
+  expect_true(opened %in% after)
+})


### PR DESCRIPTION
Fixes #227

This is new try (after PR #228) to fix the issue reported in #227 where calls to `graphics::strwidth()` and `graphics::par()` unintentionally generate `Rplots.pdf` files in some environments due to opening a new default graphics device that is never closed.

The discussion in that PR was very helpful in getting this "more proper" solution.

- Add a `with_graphics_device()` helper to run `graphics::strwidth()`/`graphics::par()` without implicitly leaving the default device open by opening a null-output device only when needed and closing it on exit.
- Refactor code under `R/` and `tests/` to use the helper.

Performance comparison:

```r
microbenchmark::microbenchmark(
  r2rtf:::with_graphics_device(graphics::strwidth("Hello world!", units = "inches", cex = 1, font = 1, family = "sans")),
  graphics::strwidth("Hello world!", units = "inches", cex = 1, font = 1, family = "sans"),
  times = 10000
)

#>   min    lq     mean median    uq    max neval cld
#> 4.305 4.715 5.132995  5.002 5.371 33.579 10000   a
#> 1.968 2.214 2.418569  2.337 2.501 26.855 10000   b
```

Note that changing this might affect some `strwidth()` calculation results slightly.